### PR TITLE
vrchatのyaiba出力ログをコピーするshell scriptを追加

### DIFF
--- a/scripts/copy-vrchat-logs.sh
+++ b/scripts/copy-vrchat-logs.sh
@@ -1,0 +1,33 @@
+#!/bin/bash
+
+# VRChat log directory path
+vrchat_log_dir=~/.steam/steam/steamapps/compatdata/438100/pfx/drive_c/users/steamuser/AppData/LocalLow/VRChat/VRChat
+
+# Set output directory based on script execution location
+script_path=$(realpath "$0")
+script_dir=$(dirname "$script_path")
+if [[ "$script_dir" == */scripts ]]; then
+    output_dir="$script_dir/../logs/vrchat-logs"
+else
+    output_dir="$script_dir/logs/vrchat-logs"
+fi
+
+# Create output directory if it doesn't exist
+mkdir -p "$output_dir"
+
+# Copy all log files
+log_files=$(find "$vrchat_log_dir" -name "output_log_*.txt")
+copied_count=0
+
+for log_file in $log_files; do
+    cp "$log_file" "$output_dir/"
+    file_name=$(basename "$log_file")
+    echo "Copied '$file_name' to 'logs/vrchat-logs'."
+    ((copied_count++))
+done
+
+if [ $copied_count -gt 0 ]; then
+    echo "Copied $copied_count log file(s)."
+else
+    echo "No log files found."
+fi


### PR DESCRIPTION
## 概要

YAIBAにより取得した VRChatのワールド位置情報のログを プロジェクトディレクトリの `logs/vrchat-logs`にコピーするシェルスクリプトを追加しました。
LinuxにおけるVRChatのログ出力先の場所は特殊であり、毎度探すのが困難です。さらに、一定時間でログファイルが消えてしまう問題もあるため、コピーするシェルスクリプトを追加しました。

実行権限を与えているため、プロジェクトディレクトリで`./scripts/copy-vrchat-logs.sh`とするだけで実行できます。

## Submit前の確認項目

<!-- PRをSubmitする前に確認する項目 -->

- [x] タイトルは一目でわかるようにし、説明文は PR を簡潔に説明するようにしましたか?
- [x] あなたの PR が、異なる変更を束ねたものではなく、ひとつのことだけを行うものであることを確認しましたか?
- [x] この PR で導入されたすべての変更点をリストアップしましたか?
- [x] PR を`make run`コマンドでローカルでテストしましたか?

## 補足

<!-- レビューをする際に見てほしい点、ローカル環境で試す際の注意点、など -->
