### PR TITLE
OneHotベクトルを処理するクラス群を追加

### DIFF
--- a/ami/models/components/one_hot.py
+++ b/ami/models/components/one_hot.py
@@ -1,0 +1,83 @@
+from typing import Any
+
+import torch
+import torch.nn as nn
+from torch import Tensor
+from torch.distributions import OneHotCategoricalStraightThrough
+
+
+class MaskedOneHotCategoricalStraightThrough(OneHotCategoricalStraightThrough):
+    """Masked OneHotCategoricalStraightThrough class.
+
+    This class extends OneHotCategoricalStraightThrough by adding
+    functionality to apply a mask, disabling specific choices.
+    """
+
+    def __init__(self, logits: Tensor, mask: Tensor, validate_args: Any = None) -> None:
+        """
+        Args:
+            logits: Tensor of logits.
+            mask: Mask tensor. True elements indicate invalid choices.
+        """
+        assert logits.shape[-mask.ndim :] == mask.shape
+        logits[..., mask] = -torch.inf
+        self.mask = mask
+        super().__init__(logits=logits, validate_args=validate_args)
+
+    def entropy(self) -> Tensor:
+        log_prob = torch.log_softmax(self.logits, dim=-1)
+        log_prob[..., self.mask] = 0.0
+        return -torch.sum(self.probs * log_prob, dim=-1)
+
+
+class MultiOneHots(nn.Module):
+    """Class for handling multiple OneHot distributions.
+
+    This class generates OneHot distributions for multiple categories.
+    Each category can have a different number of choices.
+    """
+
+    def __init__(self, in_features: int, choices_per_category: list[int]) -> None:
+        """
+        Args:
+            in_features: Number of input features.
+            choices_per_category: List of number of choices for each category.
+        """
+        super().__init__()
+
+        out_features = max(choices_per_category)
+        num_cateogies = len(choices_per_category)
+        mask = torch.zeros((num_cateogies, out_features), dtype=torch.bool)
+        for i, c in enumerate(choices_per_category):
+            assert c > 0, f"Category index {i} has no choices!"
+            mask[i, c:] = True
+
+        self.mask: Tensor
+        self.register_buffer("mask", mask)
+
+        self._layers = nn.ModuleList(nn.Linear(in_features, out_features, bias=False) for _ in choices_per_category)
+
+    def forward(self, x: Tensor) -> MaskedOneHotCategoricalStraightThrough:
+        """
+        Shapes:
+            x: (*, in_features)
+            return: (*, num_categories, max_choice)
+        """
+        out = torch.stack([lyr(x) for lyr in self._layers], dim=-2)
+        return MaskedOneHotCategoricalStraightThrough(logits=out, mask=self.mask)
+
+
+class OneHotToEmbedding(nn.Module):
+    """Make the embedding from one hot vectors."""
+
+    def __init__(self, num_embeddings: int, embedding_dim: int) -> None:
+        super().__init__()
+        self._weight = nn.Parameter(torch.randn(num_embeddings, embedding_dim), True)
+
+    def forward(self, x: Tensor) -> Tensor:
+        """
+        Shapes:
+            x: (*, num_embeddings)
+            return: (*, embedding_dim)
+        """
+        return x @ self._weight

--- a/ami/models/components/one_hot.py
+++ b/ami/models/components/one_hot.py
@@ -46,8 +46,8 @@ class MultiOneHots(nn.Module):
         super().__init__()
 
         out_features = max(choices_per_category)
-        num_cateogies = len(choices_per_category)
-        mask = torch.zeros((num_cateogies, out_features), dtype=torch.bool)
+        num_categories = len(choices_per_category)
+        mask = torch.zeros((num_categories, out_features), dtype=torch.bool)
         for i, c in enumerate(choices_per_category):
             assert c > 0, f"Category index {i} has no choices!"
             mask[i, c:] = True

--- a/tests/models/components/test_one_hot.py
+++ b/tests/models/components/test_one_hot.py
@@ -158,10 +158,10 @@ class TestOneHotToEmbedding:
     def test_one_hot_to_embedding_gradients(self):
         num_embeddings, embedding_dim = 10, 5
         one_hot_embedding = OneHotToEmbedding(num_embeddings, embedding_dim)
-        x = torch.eye(num_embeddings)
+        x = torch.eye(num_embeddings, requires_grad=True)
 
         output = one_hot_embedding(x)
+        output.sum().backward()
 
-        # Check that gradients
-        assert one_hot_embedding._weight.requires_grad is True
-        assert output.requires_grad is True
+        assert one_hot_embedding._weight.grad is not None
+        assert x.grad is not None

--- a/tests/models/components/test_one_hot.py
+++ b/tests/models/components/test_one_hot.py
@@ -1,0 +1,167 @@
+import pytest
+import torch
+import torch.nn as nn
+
+from ami.models.components.one_hot import (
+    MaskedOneHotCategoricalStraightThrough,
+    MultiOneHots,
+    OneHotToEmbedding,
+)
+
+
+class TestMaskedOneHotCategoricalStraightThrough:
+    @pytest.mark.parametrize("batch_size", [1, 32])
+    @pytest.mark.parametrize("num_categories", [5])
+    @pytest.mark.parametrize("num_choices", [3])
+    def test_initialization(self, batch_size, num_categories, num_choices):
+        logits = torch.randn(batch_size, num_categories, num_choices)
+        mask = torch.zeros(num_categories, num_choices, dtype=torch.bool)
+        mask[:, num_choices // 2 :] = True
+
+        distribution = MaskedOneHotCategoricalStraightThrough(logits=logits, mask=mask)
+
+        assert distribution.logits.shape == (batch_size, num_categories, num_choices)
+        assert torch.all(distribution.logits[..., mask] == -torch.inf)
+        assert distribution.probs.shape == (batch_size, num_categories, num_choices)
+        assert torch.all(distribution.probs[..., mask] == 0)
+
+    def test_entropy(self):
+        logits = torch.randn(1, 3, 4)
+        # fmt: off
+        mask = torch.tensor(
+            [
+                [False, False, True, True],
+                [False, False, False, True],
+                [False, True, True, True],
+            ]
+        )
+        # fmt: on
+
+        distribution = MaskedOneHotCategoricalStraightThrough(logits=logits, mask=mask)
+        entropy = distribution.entropy()
+
+        assert entropy.shape == (1, 3)
+        assert torch.all(entropy >= 0)  # Entropy should be non-negative
+        assert torch.all(torch.isfinite(entropy))
+
+    def test_log_prob(self):
+        logits = torch.randn(1, 3, 4)
+        # fmt: off
+        mask = torch.tensor(
+            [
+                [False, False, True, True],
+                [False, False, False, True],
+                [False, True, True, True],
+            ]
+        )
+        # fmt: on
+
+        distribution = MaskedOneHotCategoricalStraightThrough(logits=logits, mask=mask)
+
+        # Test with valid one-hot vectors
+        # fmt: off
+        valid_sample = torch.tensor(
+            [
+                [
+                    [1, 0, 0, 0],
+                    [0, 1, 0, 0],
+                    [1, 0, 0, 0],
+                ]
+            ]
+        )
+        # fmt: on
+        log_prob = distribution.log_prob(valid_sample)
+
+        assert log_prob.shape == (1, 3)
+        assert torch.all(torch.isfinite(log_prob))
+
+        # Test with invalid one-hot vectors (selecting masked values)
+        # fmt: off
+        invalid_sample = torch.tensor(
+            [
+                [
+                    [0, 0, 1, 0],
+                    [0, 0, 0, 1],
+                    [0, 1, 0, 0],
+                ]
+            ]
+        )
+        # fmt: on
+        log_prob_invalid = distribution.log_prob(invalid_sample)
+
+        assert torch.all(log_prob_invalid == -torch.inf)
+
+
+class TestMultiOneHots:
+    @pytest.mark.parametrize("in_features", [10])
+    @pytest.mark.parametrize("choices_per_category", [[2, 3, 4], [3, 3, 3, 2, 2]])
+    @pytest.mark.parametrize("batch_size", [1, 32])
+    def test_multi_one_hots(self, in_features, choices_per_category, batch_size):
+        # Create MultiOneHots instance
+        multi_one_hots = MultiOneHots(in_features, choices_per_category)
+
+        # Create input tensor
+        x = torch.randn(batch_size, in_features)
+
+        # Forward pass
+        output = multi_one_hots(x)
+
+        # Check output type
+        assert isinstance(output, MaskedOneHotCategoricalStraightThrough)
+
+        # Check output shapes
+        num_categories = len(choices_per_category)
+        max_choices = max(choices_per_category)
+        assert output.logits.shape == (batch_size, num_categories, max_choices)
+
+        # Check that logits for invalid choices are set to -inf
+        # Check that probs for invalid choices are set to 0
+        for i, choices in enumerate(choices_per_category):
+            assert torch.all(output.logits[:, i, choices:] == -torch.inf)
+            assert torch.all(output.probs[:, i, choices:] == 0)
+
+        # Test sampling
+        sample = output.sample()
+        assert sample.shape == (batch_size, num_categories, max_choices)
+        assert torch.all(sample.sum(dim=-1) == 1)  # One-hot property
+
+        # Test sample gradient
+        assert output.rsample().requires_grad is True
+        assert output.sample().requires_grad is False
+
+    def test_multi_one_hots_invalid_args(self):
+        with pytest.raises(AssertionError):
+            MultiOneHots(10, [0, 1, 2])  # Category with no choices
+
+
+class TestOneHotToEmbedding:
+    @pytest.mark.parametrize("num_embeddings", [10])
+    @pytest.mark.parametrize("embedding_dim", [5])
+    @pytest.mark.parametrize("batch_size", [1, 32])
+    def test_one_hot_to_embedding(self, num_embeddings, embedding_dim, batch_size):
+        # Create OneHotEmbedding instance
+        one_hot_embedding = OneHotToEmbedding(num_embeddings, embedding_dim)
+
+        # Create input tensor (one-hot vectors)
+        x = torch.eye(num_embeddings).repeat(batch_size, 1, 1)
+
+        # Forward pass
+        output = one_hot_embedding(x)
+
+        # Check output shape
+        assert output.shape == (batch_size, num_embeddings, embedding_dim)
+
+        # Check that the embedding for each one-hot vector is correct
+        for i in range(num_embeddings):
+            assert torch.allclose(output[:, i], one_hot_embedding._weight[i])
+
+    def test_one_hot_to_embedding_gradients(self):
+        num_embeddings, embedding_dim = 10, 5
+        one_hot_embedding = OneHotToEmbedding(num_embeddings, embedding_dim)
+        x = torch.eye(num_embeddings)
+
+        output = one_hot_embedding(x)
+
+        # Check that gradients
+        assert one_hot_embedding._weight.requires_grad is True
+        assert output.requires_grad is True


### PR DESCRIPTION
## 概要

#18 に関連して、離散行動を扱う上で勾配を流せるようにする必要があったため、OneHotベクトルを使用し、勾配計算が可能なクラス群を追加しました。

mypyのバージョンアップでバグが修正された関係で Testがエラーになりますが、他のPRで直されるので無視してください。
## 変更内容

* MaskedOneHotCategoricalStraightThrough: 既存のStraight Through Estimatorを使用したモデルにマスク機能を追加しました。これにより、アクション数が異なる複数種類のアクションを扱えるようになります。エントロピー計算式も追加しました。
* MultiOneHots: DiscretePolicyHeadの機能のOneHot版です。アクション数が異なる複数種類のアクションを出力する用です。
* OneHotToEmbedding: OneHotベクトルをEmbedding vectorに変換します。行列演算のため勾配が流れます。nn.Linearでも良かったんですが、bias項が常になかったりするので分かりやすさのために実装しました。

## 影響範囲

<!-- この関数を変更したのでこの機能にも影響がある、など -->

## Submit前の確認項目

<!-- PRをSubmitする前に確認する項目 -->

- [x] タイトルは一目でわかるようにし、説明文は PR を簡潔に説明するようにしましたか?
- [x] あなたの PR が、異なる変更を束ねたものではなく、ひとつのことだけを行うものであることを確認しましたか?
- [x] この PR で導入されたすべての変更点をリストアップしましたか?
- [x] PR を`make run`コマンドでローカルでテストしましたか?

## 補足

<!-- レビューをする際に見てほしい点、ローカル環境で試す際の注意点、など -->
