### PR TITLE
PolicyとValueを実装するためのフレームワーク他を実装。

### DIFF
--- a/ami/models/components/fully_connected_normal.py
+++ b/ami/models/components/fully_connected_normal.py
@@ -1,0 +1,18 @@
+import torch.nn as nn
+from torch import Tensor
+from torch.distributions import Normal
+
+
+class FullyConnectedNormal(nn.Module):
+    """The layer which returns the normal distribution."""
+
+    def __init__(self, dim_in: int, dim_out: int, eps: float = 1e-6) -> None:
+        super().__init__()
+        self.fc_mean = nn.Linear(dim_in, dim_out)
+        self.fc_std = nn.Linear(dim_in, dim_out)
+        self.eps = eps
+
+    def forward(self, x: Tensor) -> Normal:
+        mean = self.fc_mean(x)
+        std = nn.functional.softplus(self.fc_std(x)) + self.eps
+        return Normal(mean, std)

--- a/ami/models/model_names.py
+++ b/ami/models/model_names.py
@@ -6,3 +6,5 @@ class ModelNames(str, Enum):
     IMAGE_DECODER = "image_decoder"
     POLICY_VALUE = "policy_value"
     FORWARD_DYNAMICS = "forward_dynamics"
+    POLICY = "policy"
+    VALUE = "value"

--- a/ami/models/policy_or_value_network.py
+++ b/ami/models/policy_or_value_network.py
@@ -1,0 +1,39 @@
+import torch.nn as nn
+from torch import Tensor
+from torch.distributions import Distribution
+
+
+class PolicyOrValueNetwork(nn.Module):
+    """Module for policy or value network."""
+
+    def __init__(
+        self,
+        observation_projection: nn.Module,
+        forward_dynamics_hidden_projection: nn.Module,
+        observation_hidden_projection: nn.Module,
+        core_model: nn.Module,
+        dist_head: nn.Module,
+    ) -> None:
+        """Constructs the model with components.
+
+        Args:
+            observation_projection: Layer that processes observations only.
+            forward_dynamics_hidden_projection: Layer that processes hidden states of the Forward Dynamics model only.
+            observation_hidden_projection: Layer that receives and integrates observations and hidden states.
+            core_model: Layer that processes the integrated tensor.
+            dist_head: Layer that generates prediction distribution.
+        """
+        super().__init__()
+        self.observation_projection = observation_projection
+        self.forward_dynamics_hidden_projection = forward_dynamics_hidden_projection
+        self.observation_hidden_projection = observation_hidden_projection
+        self.core_model = core_model
+        self.dist_head = dist_head
+
+    def forward(self, observation: Tensor, forward_dynamics_hidden: Tensor) -> Distribution:
+        """Returns the prediction distribution."""
+        obs_embed = self.observation_projection(observation)
+        hidden_embed = self.forward_dynamics_hidden_projection(forward_dynamics_hidden)
+        x = self.observation_hidden_projection(obs_embed, hidden_embed)
+        h = self.core_model(x)
+        return self.dist_head(h)

--- a/tests/models/components/test_fully_connected_normal.py
+++ b/tests/models/components/test_fully_connected_normal.py
@@ -1,0 +1,14 @@
+import pytest
+import torch
+
+from ami.models.components.fully_connected_normal import FullyConnectedNormal, Normal
+
+
+class TestFullyConnectedNormal:
+    @pytest.mark.parametrize(["dim_in", "dim_out", "batch_size"], [(8, 16, 1), (8, 1, 1)])
+    def test_forward(self, dim_in, dim_out, batch_size):
+        m = FullyConnectedNormal(dim_in, dim_out)
+        data = torch.randn(batch_size, dim_in)
+        out = m(data)
+        assert isinstance(out, Normal)
+        assert out.rsample().shape == (batch_size, dim_out)

--- a/tests/models/test_policy_or_value_network.py
+++ b/tests/models/test_policy_or_value_network.py
@@ -1,0 +1,26 @@
+import pytest
+import torch
+import torch.nn as nn
+
+from ami.models.components.fully_connected_normal import FullyConnectedNormal
+from ami.models.policy_or_value_network import PolicyOrValueNetwork
+
+
+class CatObsHidden(nn.Module):
+    def forward(self, obs, hidden):
+        return torch.cat([obs, hidden], -1)
+
+
+class TestPolicyOrValueNetwork:
+    @pytest.fixture
+    def net(self) -> PolicyOrValueNetwork:
+        obs_layer = nn.Linear(128, 64)
+        hidden_layer = nn.Linear(256, 128)
+        obs_hidden_proj = CatObsHidden()
+        core_model = nn.Linear(128 + 64, 16)
+        head = FullyConnectedNormal(16, 8)
+        return PolicyOrValueNetwork(obs_layer, hidden_layer, obs_hidden_proj, core_model, head)
+
+    def test_forward(self, net: PolicyOrValueNetwork):
+        dist = net.forward(torch.randn(128), torch.randn(256))
+        assert dist.sample().shape == (8,)


### PR DESCRIPTION
## 概要

#18 
Dreamerの学習を実装するために必要な 方策と価値関数のフレームワーククラスを実装した。
また、Dreamer V3において 価値関数が確率的に予測する実装になっていたため、それを実装するための`Normal`を出力するレイヤーも実装した。
![スクリーンショット 2024-07-25 午後3 20 48](https://github.com/user-attachments/assets/a5428d43-4192-4561-9a37-b656716f8f1a)

## Submit前の確認項目

<!-- PRをSubmitする前に確認する項目 -->

- [x] タイトルは一目でわかるようにし、説明文は PR を簡潔に説明するようにしましたか?
- [x] あなたの PR が、異なる変更を束ねたものではなく、ひとつのことだけを行うものであることを確認しましたか?
- [x] この PR で導入されたすべての変更点をリストアップしましたか?
- [x] PR を`make run`コマンドでローカルでテストしましたか?

## 補足

<!-- レビューをする際に見てほしい点、ローカル環境で試す際の注意点、など -->
