### PR TITLE
Dreamer方式の方策と価値関数のTrainerを実装

### DIFF
--- a/ami/data/buffers/buffer_names.py
+++ b/ami/data/buffers/buffer_names.py
@@ -5,3 +5,4 @@ class BufferNames(str, Enum):
     IMAGE = "image"
     PPO_TRAJECTORY = "ppo_trajectory"
     FORWARD_DYNAMICS_TRAJECTORY = "forward_dynamics_trajectory"
+    DREAMING_INITIAL_STATES = "dreaming_initial_states"

--- a/ami/trainers/dreaming_policy_value_trainer.py
+++ b/ami/trainers/dreaming_policy_value_trainer.py
@@ -141,6 +141,9 @@ class DreamingPolicyValueTrainer(BaseTrainer):
                 observation = observation.to(self.device)
                 hidden = hidden.to(self.device)
 
+                # Value network is used only inference in the imagination.
+                self.value_net.freeze_model()
+
                 trajectory = self.imagine_trajectory(initial_state=(observation, hidden))
 
                 returns = compute_lambda_return(
@@ -161,6 +164,7 @@ class DreamingPolicyValueTrainer(BaseTrainer):
                 returns = returns.detach()
 
                 # Update value network.
+                self.value_net.unfreeze_model()
                 value_optimizer.zero_grad()
                 value_losses = []
                 for i in range(self.imagination_trajectory_length):

--- a/ami/trainers/dreaming_policy_value_trainer.py
+++ b/ami/trainers/dreaming_policy_value_trainer.py
@@ -1,29 +1,30 @@
-from pathlib import Path
-from .base_trainer import BaseTrainer
 from functools import partial
+from pathlib import Path
 
 import torch
 from torch import Tensor
-from torch.utils.data import DataLoader
-from torch.optim import Optimizer
-from typing_extensions import override
 from torch.distributions import Distribution
+from torch.optim import Optimizer
+from torch.utils.data import DataLoader
+from typing_extensions import override
 
 from ami.data.buffers.buffer_names import BufferNames
 from ami.data.buffers.random_data_buffer import RandomDataBuffer
-from ami.tensorboard_loggers import StepIntervalLogger
 from ami.data.interfaces import ThreadSafeDataUser
+from ami.models.forward_dynamics import ForwardDynamcisWithActionReward
 from ami.models.model_names import ModelNames
 from ami.models.model_wrapper import ModelWrapper
-from ami.models.forward_dynamics import ForwardDynamcisWithActionReward
 from ami.models.policy_or_value_network import PolicyOrValueNetwork
+from ami.tensorboard_loggers import StepIntervalLogger
+
+from .base_trainer import BaseTrainer
+
 
 class DreamingPolicyValueTrainer(BaseTrainer):
     """Training the policy and value model by Dreamer method.
-    
+
     References:
         Dreamer V1
-        Danijar Hafner, Timothy Lillicrap, Jimmy Ba and Mohammad Norouzi,
         "Dream to Control: Learning Behaviors by Latent Imagination",
         arXiv:1912.01603, 2019.
     """
@@ -37,16 +38,15 @@ class DreamingPolicyValueTrainer(BaseTrainer):
         device: torch.device,
         logger: StepIntervalLogger,
         max_epochs: int = 1,
-        imagination_trajectory_length = 1,
-        discount_factor: float = 0.99, # gamma for rl
-        eligibility_trace_decay: float = 0.95, # for lambda-return 
+        imagination_trajectory_length: int = 1,
+        discount_factor: float = 0.99,  # gamma for rl
+        eligibility_trace_decay: float = 0.95,  # for lambda-return
         entropy_coef: float = 0.001,
         minimum_dataset_size: int = 1,
         minimum_new_data_count: int = 0,
-        
     ) -> None:
         """Initializes an Dreaming PolicyValueTrainer object.
-        
+
         Args:
             partial_dataloader: A partially instantiated dataloader lacking a provided dataset.
             partial_policy_optimizer: A partially instantiated optimizer for policy lacking provided parameters.
@@ -78,7 +78,9 @@ class DreamingPolicyValueTrainer(BaseTrainer):
 
     @override
     def on_model_wrappers_dict_attached(self) -> None:
-        self.forward_dynamics: ModelWrapper[ForwardDynamcisWithActionReward] = self.get_frozen_model(ModelNames.FORWARD_DYNAMICS)
+        self.forward_dynamics: ModelWrapper[ForwardDynamcisWithActionReward] = self.get_frozen_model(
+            ModelNames.FORWARD_DYNAMICS
+        )
 
         self.policy_net: ModelWrapper[PolicyOrValueNetwork] = self.get_training_model(ModelNames.POLICY)
         self.value_net: ModelWrapper[PolicyOrValueNetwork] = self.get_training_model(ModelNames.VALUE)
@@ -118,76 +120,35 @@ class DreamingPolicyValueTrainer(BaseTrainer):
         for _ in range(self.max_epochs):
             for batch in dataloader:
                 # Initial states setup.
-                observation: Tensor 
-                hidden: Tensor
-                observation, hidden = batch 
+                observation, hidden = batch
                 observation = observation.to(self.device)
                 hidden = hidden.to(self.device)
 
-                # Imagine.
-                observations: list[Tensor] = [observation] # o_0:H+1
-                hiddens: list[Tensor] = [hidden] # h_0:H+1
-                actions: list[Tensor] = [] # a_0:H
-                action_entropies: list[Tensor] = []
-                rewards: list[Tensor] = [] # r_1:H+1
-                values: list[Tensor] = [] # v_0:H+1
-                value_distributions: list[Distribution] = [] # p_0:H
+                observations, hiddens, _, action_entropies, rewards, next_values = self.imagine_trajectory(
+                    initial_state=(observation, hidden)
+                )
 
-                for _ in range(self.imagination_trajectory_length): # H step
-                    
-                    # Take one step.
-                    action_dist: Distribution = self.policy_net(observation, hidden)
-                    action = action_dist.rsample()
-                    value_dist: Distribution = self.value_net(observation, hidden)
-                    value = value_dist.rsample()
+                returns = compute_lambda_return(
+                    rewards, next_values, self.discount_factor, self.eligibility_trace_decay
+                )
 
-                    actions.append(action)
-                    action_entropies.append(action_dist.entropy())
-                    values.append(value)
-                    value_distributions.append(value_dist)
-
-                    next_obs_dist: Distribution
-                    reward_dist: Distribution
-                    next_hidden: Tensor
-                    next_obs_dist, _, reward_dist, next_hidden = self.forward_dynamics(observation, hidden, action)
-
-                    observation = next_obs_dist.rsample()
-                    reward = reward_dist.rsample()
-                    hidden = next_hidden
-
-                    # Add list
-                    observations.append(observation)
-                    hiddens.append(hidden)
-                    rewards.append(reward)
-
-                # Add next value v_H+1
-                value_dist: Distribution = self.value_net(observation, hidden)
-                value = value_dist.rsample()
-                values.append(value)
-
-                # Stacking
-                observations = torch.stack(observations)
-                hiddens = torch.stack(hiddens)
-                actions = torch.stack(actions)
-                action_entropies = torch.stack(action_entropies)
-                rewards = torch.stack(rewards)
-                values = torch.stack(values)
-
-                # Compute Return
-                returns = compute_lambda_return(rewards, values[1:], self.discount_factor, self.eligibility_trace_decay)
-
-                # Update policy network.
+                # Update policy network
                 policy_optimizer.zero_grad()
                 entropy_loss = action_entropies.mean()
                 return_loss = returns.sum(0).mean()
-                policy_loss = - (return_loss + entropy_loss * self.entropy_coef) # maximize.
+                policy_loss = -(return_loss + entropy_loss * self.entropy_coef)  # maximize.
                 policy_loss.backward()
                 policy_optimizer.step()
 
                 # Update value network.
                 value_optimizer.zero_grad()
-                value_losses = -torch.stack([dist.log_prob(returns[i].detach()) for i, dist in enumerate(value_distributions)])
-                value_loss = value_losses.mean()
+                value_losses: list[Tensor] = []
+                for i in range(self.imagination_trajectory_length):
+                    obs, hidden = observations[i].detach(), hiddens[i].detach()
+                    target = returns[i].detach()
+                    value_dist: Distribution = self.value_net(obs, hidden)
+                    value_losses.append(-value_dist.log_prob(target).mean())
+                value_loss = torch.mean(torch.stack(value_losses))
                 value_loss.backward()
                 value_optimizer.step()
 
@@ -201,6 +162,61 @@ class DreamingPolicyValueTrainer(BaseTrainer):
 
         self.policy_optimizer_state = policy_optimizer.state_dict()
         self.value_optimizer_state = value_optimizer.state_dict()
+
+    def imagine_trajectory(self, initial_state: tuple[Tensor, Tensor]) -> tuple[Tensor, ...]:
+        """
+        Args:
+            initial_state: observation and hidden state.
+
+        Returns:
+            tuple[Tensor, ...]: observations, hiddens, actions, action_entopies, rewards, next_values.
+                The first dimension is imagination trajectory length.
+
+        """
+        observation, hidden = initial_state
+
+        # Setup buffers
+        observations: list[Tensor] = [observation]  # o_0:H+1
+        hiddens: list[Tensor] = [hidden]  # h_0:H+1
+        actions: list[Tensor] = []  # a_0:H
+        action_entropies: list[Tensor] = []
+        rewards: list[Tensor] = []  # r_1:H+1
+        next_values: list[Tensor] = []  # v_1:H+1
+
+        for _ in range(self.imagination_trajectory_length):  # H step
+
+            # Take one step.
+            action_dist: Distribution = self.policy_net(observation, hidden)
+            action = action_dist.rsample()
+
+            next_obs_dist: Distribution
+            reward_dist: Distribution
+            next_hidden: Tensor
+            next_obs_dist, _, reward_dist, next_hidden = self.forward_dynamics(observation, hidden, action)
+
+            observation = next_obs_dist.rsample()
+            reward = reward_dist.rsample()
+            hidden = next_hidden
+
+            value_dist: Distribution = self.value_net(observation, hidden)
+            next_value = value_dist.rsample()
+
+            # Add to list
+            actions.append(action)
+            action_entropies.append(action_dist.entropy())
+            observations.append(observation)
+            hiddens.append(hidden)
+            rewards.append(reward)
+            next_values.append(next_value)
+
+        return (
+            torch.stack(observations),
+            torch.stack(hiddens),
+            torch.stack(actions),
+            torch.stack(action_entropies),
+            torch.stack(rewards),
+            torch.stack(next_values),
+        )
 
     @override
     def save_state(self, path: Path) -> None:
@@ -216,17 +232,19 @@ class DreamingPolicyValueTrainer(BaseTrainer):
         self.logger.load_state_dict(torch.load(path / "logger.pt"))
 
 
-def compute_lambda_return(rewards: Tensor, next_values: Tensor, discount_factor: float, eligibility_trace_decay: float) -> Tensor:
+def compute_lambda_return(
+    rewards: Tensor, next_values: Tensor, discount_factor: float, eligibility_trace_decay: float
+) -> Tensor:
     """Computes the lambda Return.
-    
+
     Args:
         rewards: r_1:T+1, (L, *)
         next_values: v_1:T+1, (L, *)
         discount_factor: gamma.
         eligibility_trace_decay: lambda.
-    
+
     Returns:
-        lambda_returns: G_0:T, (L, *).
+        lambda_returns: g_0:T, (L, *).
     """
     assert rewards.shape == next_values.shape
 
@@ -235,10 +253,8 @@ def compute_lambda_return(rewards: Tensor, next_values: Tensor, discount_factor:
 
     for i in reversed(range(rewards.size(0))):
         last_lambda_return = rewards[i] + discount_factor * (
-            (1-eligibility_trace_decay) * next_values[i] + eligibility_trace_decay * last_lambda_return
+            (1 - eligibility_trace_decay) * next_values[i] + eligibility_trace_decay * last_lambda_return
         )
         lambda_returns.append(last_lambda_return)
 
     return torch.stack(list(reversed(lambda_returns)))
-    
-    

--- a/ami/trainers/dreaming_policy_value_trainer.py
+++ b/ami/trainers/dreaming_policy_value_trainer.py
@@ -1,0 +1,244 @@
+from pathlib import Path
+from .base_trainer import BaseTrainer
+from functools import partial
+
+import torch
+from torch import Tensor
+from torch.utils.data import DataLoader
+from torch.optim import Optimizer
+from typing_extensions import override
+from torch.distributions import Distribution
+
+from ami.data.buffers.buffer_names import BufferNames
+from ami.data.buffers.random_data_buffer import RandomDataBuffer
+from ami.tensorboard_loggers import StepIntervalLogger
+from ami.data.interfaces import ThreadSafeDataUser
+from ami.models.model_names import ModelNames
+from ami.models.model_wrapper import ModelWrapper
+from ami.models.forward_dynamics import ForwardDynamcisWithActionReward
+from ami.models.policy_or_value_network import PolicyOrValueNetwork
+
+class DreamingPolicyValueTrainer(BaseTrainer):
+    """Training the policy and value model by Dreamer method.
+    
+    References:
+        Dreamer V1
+        Danijar Hafner, Timothy Lillicrap, Jimmy Ba and Mohammad Norouzi,
+        "Dream to Control: Learning Behaviors by Latent Imagination",
+        arXiv:1912.01603, 2019.
+    """
+
+    @override
+    def __init__(
+        self,
+        partial_dataloader: partial[DataLoader[Tensor]],
+        partial_policy_optimizer: partial[Optimizer],
+        partial_value_optimizer: partial[Optimizer],
+        device: torch.device,
+        logger: StepIntervalLogger,
+        max_epochs: int = 1,
+        imagination_trajectory_length = 1,
+        discount_factor: float = 0.99, # gamma for rl
+        eligibility_trace_decay: float = 0.95, # for lambda-return 
+        entropy_coef: float = 0.001,
+        minimum_dataset_size: int = 1,
+        minimum_new_data_count: int = 0,
+        
+    ) -> None:
+        """Initializes an Dreaming PolicyValueTrainer object.
+        
+        Args:
+            partial_dataloader: A partially instantiated dataloader lacking a provided dataset.
+            partial_policy_optimizer: A partially instantiated optimizer for policy lacking provided parameters.
+            partial_value_optimizer: A partially instantiated optimizer for value lacking provided parameters.
+            device: The accelerator device (e.g., CPU, GPU) utilized for training the model.
+            imagination_trajectory_length: The length of dreaming steps.
+            ...
+            minimum_new_data_count: Minimum number of new data count required to run the training.
+        """
+        super().__init__()
+        self.partial_data_loader = partial_dataloader
+        self.partial_policy_optimizer = partial_policy_optimizer
+        self.partial_value_optimizer = partial_value_optimizer
+        self.device = device
+        self.logger = logger
+        self.max_epochs = max_epochs
+        self.imagination_trajectory_length = imagination_trajectory_length
+        self.discount_factor = discount_factor
+        self.eligibility_trace_decay = eligibility_trace_decay
+        self.entropy_coef = entropy_coef
+        self.minimum_dataset_size = minimum_dataset_size
+        self.minimum_new_data_count = minimum_new_data_count
+
+    @override
+    def on_data_users_dict_attached(self) -> None:
+        self.initial_states_data_user: ThreadSafeDataUser[RandomDataBuffer] = self.get_data_user(
+            BufferNames.DREAMING_INITIAL_STATES
+        )
+
+    @override
+    def on_model_wrappers_dict_attached(self) -> None:
+        self.forward_dynamics: ModelWrapper[ForwardDynamcisWithActionReward] = self.get_frozen_model(ModelNames.FORWARD_DYNAMICS)
+
+        self.policy_net: ModelWrapper[PolicyOrValueNetwork] = self.get_training_model(ModelNames.POLICY)
+        self.value_net: ModelWrapper[PolicyOrValueNetwork] = self.get_training_model(ModelNames.VALUE)
+
+        self.policy_optimizer_state = self.partial_policy_optimizer(self.policy_net.parameters()).state_dict()
+        self.value_optimizer_state = self.partial_value_optimizer(self.value_net.parameters()).state_dict()
+
+    @override
+    def is_trainable(self) -> bool:
+        self.initial_states_data_user.update()
+        return self._is_minimum_data_available() and self._is_new_data_available()
+
+    def _is_minimum_data_available(self) -> bool:
+        return len(self.initial_states_data_user.buffer) >= self.minimum_dataset_size
+
+    def _is_new_data_available(self) -> bool:
+        return self.initial_states_data_user.buffer.new_data_count >= self.minimum_new_data_count
+
+    @override
+    def train(self) -> None:
+        # Setup model device.
+        self.forward_dynamics.to(self.device)
+        self.policy_net.to(self.device)
+        self.value_net.to(self.device)
+
+        # Setup optimizers.
+        policy_optimizer = self.partial_policy_optimizer(self.policy_net.parameters())
+        policy_optimizer.load_state_dict(self.policy_optimizer_state)
+        value_optimizer = self.partial_value_optimizer(self.value_net.parameters())
+        value_optimizer.load_state_dict(self.value_optimizer_state)
+
+        # Setup dataset
+        dataset = self.initial_states_data_user.get_dataset()
+        dataloader = self.partial_data_loader(dataset=dataset)
+
+        # Training.
+        for _ in range(self.max_epochs):
+            for batch in dataloader:
+                # Initial states setup.
+                observation: Tensor 
+                hidden: Tensor
+                observation, hidden = batch 
+                observation = observation.to(self.device)
+                hidden = hidden.to(self.device)
+
+                # Imagine.
+                observations: list[Tensor] = [observation] # o_0:H+1
+                hiddens: list[Tensor] = [hidden] # h_0:H+1
+                actions: list[Tensor] = [] # a_0:H
+                action_entropies: list[Tensor] = []
+                rewards: list[Tensor] = [] # r_1:H+1
+                values: list[Tensor] = [] # v_0:H+1
+                value_distributions: list[Distribution] = [] # p_0:H
+
+                for _ in range(self.imagination_trajectory_length): # H step
+                    
+                    # Take one step.
+                    action_dist: Distribution = self.policy_net(observation, hidden)
+                    action = action_dist.rsample()
+                    value_dist: Distribution = self.value_net(observation, hidden)
+                    value = value_dist.rsample()
+
+                    actions.append(action)
+                    action_entropies.append(action_dist.entropy())
+                    values.append(value)
+                    value_distributions.append(value_dist)
+
+                    next_obs_dist: Distribution
+                    reward_dist: Distribution
+                    next_hidden: Tensor
+                    next_obs_dist, _, reward_dist, next_hidden = self.forward_dynamics(observation, hidden, action)
+
+                    observation = next_obs_dist.rsample()
+                    reward = reward_dist.rsample()
+                    hidden = next_hidden
+
+                    # Add list
+                    observations.append(observation)
+                    hiddens.append(hidden)
+                    rewards.append(reward)
+
+                # Add next value v_H+1
+                value_dist: Distribution = self.value_net(observation, hidden)
+                value = value_dist.rsample()
+                values.append(value)
+
+                # Stacking
+                observations = torch.stack(observations)
+                hiddens = torch.stack(hiddens)
+                actions = torch.stack(actions)
+                action_entropies = torch.stack(action_entropies)
+                rewards = torch.stack(rewards)
+                values = torch.stack(values)
+
+                # Compute Return
+                returns = compute_lambda_return(rewards, values[1:], self.discount_factor, self.eligibility_trace_decay)
+
+                # Update policy network.
+                policy_optimizer.zero_grad()
+                entropy_loss = action_entropies.mean()
+                return_loss = returns.sum(0).mean()
+                policy_loss = - (return_loss + entropy_loss * self.entropy_coef) # maximize.
+                policy_loss.backward()
+                policy_optimizer.step()
+
+                # Update value network.
+                value_optimizer.zero_grad()
+                value_losses = -torch.stack([dist.log_prob(returns[i].detach()) for i, dist in enumerate(value_distributions)])
+                value_loss = value_losses.mean()
+                value_loss.backward()
+                value_optimizer.step()
+
+                # Logging
+                prefix = "dreaming_policy_value/"
+                self.logger.log(prefix + "return", return_loss)
+                self.logger.log(prefix + "entropy", entropy_loss)
+                self.logger.log(prefix + "policy_loss", policy_loss)
+                self.logger.log(prefix + "value_loss", value_loss)
+                self.logger.update()
+
+        self.policy_optimizer_state = policy_optimizer.state_dict()
+        self.value_optimizer_state = value_optimizer.state_dict()
+
+    @override
+    def save_state(self, path: Path) -> None:
+        path.mkdir()
+        torch.save(self.policy_optimizer_state, path / "policy_optimizer.pt")
+        torch.save(self.value_optimizer_state, path / "value_optimizer.pt")
+        torch.save(self.logger.state_dict(), path / "logger.pt")
+
+    @override
+    def load_state(self, path: Path) -> None:
+        self.policy_optimizer_state = torch.load(path / "policy_optimizer.pt")
+        self.value_optimizer_state = torch.load(path / "value_optimizer.pt")
+        self.logger.load_state_dict(torch.load(path / "logger.pt"))
+
+
+def compute_lambda_return(rewards: Tensor, next_values: Tensor, discount_factor: float, eligibility_trace_decay: float) -> Tensor:
+    """Computes the lambda Return.
+    
+    Args:
+        rewards: r_1:T+1, (L, *)
+        next_values: v_1:T+1, (L, *)
+        discount_factor: gamma.
+        eligibility_trace_decay: lambda.
+    
+    Returns:
+        lambda_returns: G_0:T, (L, *).
+    """
+    assert rewards.shape == next_values.shape
+
+    lambda_returns = []
+    last_lambda_return = next_values[-1]
+
+    for i in reversed(range(rewards.size(0))):
+        last_lambda_return = rewards[i] + discount_factor * (
+            (1-eligibility_trace_decay) * next_values[i] + eligibility_trace_decay * last_lambda_return
+        )
+        lambda_returns.append(last_lambda_return)
+
+    return torch.stack(list(reversed(lambda_returns)))
+    
+    

--- a/tests/trainers/test_dreaming_policy_value_trainer.py
+++ b/tests/trainers/test_dreaming_policy_value_trainer.py
@@ -1,0 +1,159 @@
+from functools import partial
+
+import pytest
+import torch
+import torch.nn as nn
+from torch.optim import Adam
+from torch.utils.data import DataLoader
+
+from ami.data.step_data import DataKeys, StepData
+from ami.data.utils import DataCollectorsDict, DataUsersDict
+from ami.models.components.fully_connected_normal import FullyConnectedNormal
+from ami.models.components.sioconv import SioConv
+from ami.models.components.fc_complex_to_real import FCComplexToReal
+from ami.models.policy_value_common_net import ConcatFlattenedObservationAndLerpedHidden, LerpStackedHidden
+from ami.models.utils import ModelWrappersDict
+from ami.tensorboard_loggers import StepIntervalLogger
+from ami.trainers.dreaming_policy_value_trainer import (
+    DreamingPolicyValueTrainer,
+    ForwardDynamcisWithActionReward,
+    ModelNames,
+    ModelWrapper,
+    StepIntervalLogger,
+    PolicyOrValueNetwork,
+    BufferNames,
+    RandomDataBuffer
+)
+
+
+BATCH = 4
+DEPTH = 8
+DIM = 16
+DIM_FF_HIDDEN = 32
+LEN = 64
+DROPOUT = 0.1
+DIM_OBS = 32
+DIM_ACTION = 8
+CHUNK_SIZE = 16
+NUM_HEAD = 4
+
+
+class TestDreamingPolicyValueTrainer:
+    @pytest.fixture
+    def forward_dynamics(self):
+        return ForwardDynamcisWithActionReward(
+            nn.Identity(),
+            nn.Identity(),
+            nn.Linear(DIM_OBS + DIM_ACTION, DIM),
+            SioConv(DEPTH, DIM, NUM_HEAD, DIM_FF_HIDDEN, DROPOUT, CHUNK_SIZE),
+            FullyConnectedNormal(DIM, DIM_OBS),
+            FullyConnectedNormal(DIM, DIM_ACTION),
+            FullyConnectedNormal(DIM, 1)
+        )
+
+    @pytest.fixture
+    def policy_net(self):
+        return PolicyOrValueNetwork(
+            nn.Identity(),
+            LerpStackedHidden(DIM, DEPTH, NUM_HEAD),
+            ConcatFlattenedObservationAndLerpedHidden(DIM_OBS, DIM, DIM),
+            nn.ReLU(),
+            FullyConnectedNormal(DIM, DIM_ACTION)
+        )
+
+    @pytest.fixture
+    def value_net(self):
+        return PolicyOrValueNetwork(
+            nn.Identity(),
+            LerpStackedHidden(DIM, DEPTH, NUM_HEAD),
+            ConcatFlattenedObservationAndLerpedHidden(DIM_OBS, DIM, DIM),
+            nn.ReLU(),
+            FullyConnectedNormal(DIM, 1)
+        )
+
+    @pytest.fixture
+    def data_users_dict(self):
+        data = StepData()
+        data[DataKeys.OBSERVATION] = torch.randn(DIM_OBS)
+        data[DataKeys.HIDDEN] = torch.randn(DEPTH, DIM)
+
+        d = DataCollectorsDict.from_data_buffers(
+            **{
+                BufferNames.DREAMING_INITIAL_STATES: RandomDataBuffer.reconstructable_init(
+                    32, [DataKeys.OBSERVATION, DataKeys.HIDDEN]
+                )
+            }
+        )
+        d.collect(data)
+        d.collect(data)
+        d.collect(data)
+        d.collect(data)
+        return d.get_data_users()
+
+    @pytest.fixture
+    def partial_dataloader(self):
+        partial_dataloader = partial(DataLoader, batch_size=2, shuffle=True)
+        return partial_dataloader
+
+    @pytest.fixture
+    def partial_policy_optimizer(self):
+        partial_optimizer = partial(Adam, lr=0.001)
+        return partial_optimizer
+
+    @pytest.fixture
+    def partial_value_optimizer(self):
+        partial_optimizer = partial(Adam, lr=0.001)
+        return partial_optimizer
+
+    @pytest.fixture
+    def model_wrappers_dict(self, forward_dynamics, policy_net, value_net, device):
+        d = ModelWrappersDict(
+            {
+                ModelNames.FORWARD_DYNAMICS: ModelWrapper(forward_dynamics, device, True),
+                ModelNames.POLICY: ModelWrapper(policy_net, device, True),
+                ModelNames.VALUE: ModelWrapper(value_net, device, True),
+            }
+        )
+        d.send_to_default_device()
+        return d
+
+    @pytest.fixture
+    def logger(self, tmp_path):
+        return StepIntervalLogger(f"{tmp_path}/tensorboard", 1)
+
+    @pytest.fixture
+    def trainer(
+        self,
+        partial_dataloader,
+        partial_policy_optimizer,
+        partial_value_optimizer,
+        device,
+        model_wrappers_dict,
+        data_users_dict,
+        logger
+    ):
+        trainer = DreamingPolicyValueTrainer(
+            partial_dataloader,
+            partial_policy_optimizer,
+            partial_value_optimizer,
+            device,
+            logger,
+            imagination_trajectory_length=8,
+        )
+        trainer.attach_model_wrappers_dict(model_wrappers_dict)
+        trainer.attach_data_users_dict(data_users_dict)
+        return trainer
+
+    def test_run(self, trainer: DreamingPolicyValueTrainer):
+        trainer.run()
+
+    def test_is_trainable(self, trainer: DreamingPolicyValueTrainer) -> None:
+        assert trainer.is_trainable() is True
+        trainer.initial_states_data_user.clear()
+        assert trainer.is_trainable() is False
+
+    def test_is_new_data_available(self, trainer: DreamingPolicyValueTrainer):
+        trainer.initial_states_data_user.update()
+        assert trainer._is_new_data_available() is True
+        trainer.run()
+        assert trainer._is_new_data_available() is False


### PR DESCRIPTION
## 概要

#28 をまずマージしてください。

#18 Dreamer方式のPolicyとValueのTrainerを実装しました。
Dreamer V2以降では Policy Lossに方策勾配法も用いていますが、今回は Dreamer V1の収益最大化のみの実装です。

Random Data Bufferに初期状態（埋め込み観測と隠れ状態）を保存し、そこから空想上の軌道を生成します。
David HaらのWorld Modelsでは、Forward Dynamicsで未来観測を生成する際の不確実性（温度パラメータ）も存在したため、TrainerかMixtureDensityNetworkかに後に実装しようと思います。

収益が時間軸に対して総和を取る実装`sum(0)`になっている理由としては、収益は時間方向に対して減衰するため、収益を下手に時間方向でスケールさせてしまう`mean`は良くないのではないかと思ったためです。Dreamerの実装でも時間方向には和をとっているのでそうしました。
ただ、価値関数の損失は時間方向に依存しないので、時間方向も`mean`で損失を計算しています。


## Submit前の確認項目

<!-- PRをSubmitする前に確認する項目 -->

- [x] タイトルは一目でわかるようにし、説明文は PR を簡潔に説明するようにしましたか?
- [x] あなたの PR が、異なる変更を束ねたものではなく、ひとつのことだけを行うものであることを確認しましたか?
- [x] この PR で導入されたすべての変更点をリストアップしましたか?
- [x] PR を`make run`コマンドでローカルでテストしましたか?

## 補足

<!-- レビューをする際に見てほしい点、ローカル環境で試す際の注意点、など -->
