### PR TITLE
MacOS上で`make docker-build`が通るように修正。

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -8,7 +8,12 @@ ADD ./ /workspace/
 # Install dependencies
 ARG DEBIAN_FRONTEND=noninteractive
 RUN ln -sf /usr/share/zoneinfo/Asia/Tokyo /etc/localtime
-# RUN perl -p -i.bak -e 's%(deb(?:-src|)\s+)https?://(?!archive\.canonical\.com|security\.ubuntu\.com)[^\s]+%$1http://ftp.naist.jp/pub/Linux/ubuntu/%' /etc/apt/sources.list
+# Change apt source to japan
+# For linux host (x86_64)
+RUN sed -i -e 's|archive.ubuntu.com/ubuntu|ftp.naist.jp/pub/Linux/ubuntu|g' /etc/apt/sources.list
+# For linux or mac host (arm64)
+RUN sed -i -e 's|ports.ubuntu.com|jp.mirror.coganng.com|g' /etc/apt/sources.list
+
 RUN apt-get update && apt-get install -y \
     curl \
     git \
@@ -21,6 +26,7 @@ RUN apt-get update && apt-get install -y \
     x11-utils \
     libgl1-mesa-glx \
     libgl1-mesa-dri \
+    libhdf5-dev \
     && rm -rf /var/lib/apt/lists/*
 
 # Install python dependencies

--- a/Dockerfile
+++ b/Dockerfile
@@ -8,7 +8,7 @@ ADD ./ /workspace/
 # Install dependencies
 ARG DEBIAN_FRONTEND=noninteractive
 RUN ln -sf /usr/share/zoneinfo/Asia/Tokyo /etc/localtime
-RUN perl -p -i.bak -e 's%(deb(?:-src|)\s+)https?://(?!archive\.canonical\.com|security\.ubuntu\.com)[^\s]+%$1http://ftp.naist.jp/pub/Linux/ubuntu/%' /etc/apt/sources.list
+# RUN perl -p -i.bak -e 's%(deb(?:-src|)\s+)https?://(?!archive\.canonical\.com|security\.ubuntu\.com)[^\s]+%$1http://ftp.naist.jp/pub/Linux/ubuntu/%' /etc/apt/sources.list
 RUN apt-get update && apt-get install -y \
     curl \
     git \

--- a/Makefile
+++ b/Makefile
@@ -30,13 +30,24 @@ run: format test-full type
 docker-build: ## Build docker image.
 	docker build -t ami-vconf24 --no-cache .
 
+# Docker GPU Option.
+USING_GPU_INDICES=all
+
+GPU_AVAILABLE := $(shell [ -f /proc/driver/nvidia/version ] && echo 1 || echo 0)
+
+ifeq ($(GPU_AVAILABLE),1)
+    DOCKER_GPU_OPTION := --gpus $(USING_GPU_INDICES)
+else
+    DOCKER_GPU_OPTION :=
+endif
+
 docker-run: ## Run built docker image.
-	docker run -it --gpus all \
+	docker run -it $(DOCKER_GPU_OPTION) \
 	--mount type=volume,source=ami-vconf24,target=/workspace \
 	ami-vconf24
 
 docker-run-host: ## Run the built Docker image along with network, camera, and other host OS device access
-	docker run -it --gpus all \
+	docker run -it $(DOCKER_GPU_OPTION) \
 	--mount type=volume,source=ami-vconf24,target=/workspace \
 	--mount type=bind,source=`pwd`/logs,target=/workspace/logs \
 	--device `v4l2-ctl --list-devices | grep -A 1 'OBS Virtual Camera' | grep -oP '\t\K/dev.*'`:/dev/video0:mwr \
@@ -44,7 +55,7 @@ docker-run-host: ## Run the built Docker image along with network, camera, and o
 	ami-vconf24
 
 docker-run-unity: ## Run the built Docker image with Unity executables
-	docker run -it --gpus all \
+	docker run -it $(DOCKER_GPU_OPTION) \
 	--mount type=volume,source=ami-vconf24,target=/workspace \
 	--mount type=bind,source=`pwd`/logs,target=/workspace/logs \
 	--mount type=bind,source=`pwd`/unity_executables,target=/workspace/unity_executables \

--- a/Makefile
+++ b/Makefile
@@ -31,7 +31,7 @@ docker-build: ## Build docker image.
 	docker build -t ami-vconf24 --no-cache .
 
 # Docker GPU Option.
-USING_GPU_INDICES=all
+USING_GPU_INDICES := all
 
 GPU_AVAILABLE := $(shell [ -f /proc/driver/nvidia/version ] && echo 1 || echo 0)
 

--- a/Makefile
+++ b/Makefile
@@ -31,12 +31,12 @@ docker-build: ## Build docker image.
 	docker build -t ami-vconf24 --no-cache .
 
 # Docker GPU Option.
-USING_GPU_INDICES := all
+USING_GPU_DEVICES := all # Index 0,1,2, ... or device UUID.
 
 GPU_AVAILABLE := $(shell [ -f /proc/driver/nvidia/version ] && echo 1 || echo 0)
 
 ifeq ($(GPU_AVAILABLE),1)
-    DOCKER_GPU_OPTION := --gpus $(USING_GPU_INDICES)
+    DOCKER_GPU_OPTION := --gpus device=$(USING_GPU_DEVICES)
 else
     DOCKER_GPU_OPTION :=
 endif


### PR DESCRIPTION
## 概要

MacでもDocker環境を使えるようにしました。ただ、Mac上のLinuxはtime.sleepの精度がイマイチなのでいくつかテストが失敗します。`make run -k`と実行すると途中でエラー出ても続行するのでそちらを使いましょう。

Arm版のubuntu mirror サーバは高速なものに変更していますが、自らの責任で使用する必要があります。 https://jp.mirror.coganng.com/ubuntu/

## 変更内容

<!-- ビューの変更がある場合はスクショによる比較などがあるとわかりやすい -->

## 影響範囲

<!-- この関数を変更したのでこの機能にも影響がある、など -->

## Submit前の確認項目

<!-- PRをSubmitする前に確認する項目 -->

- [x] タイトルは一目でわかるようにし、説明文は PR を簡潔に説明するようにしましたか?
- [x] あなたの PR が、異なる変更を束ねたものではなく、ひとつのことだけを行うものであることを確認しましたか?
- [x] この PR で導入されたすべての変更点をリストアップしましたか?
- [x] PR を`make run`コマンドでローカルでテストしましたか?

## 補足

<!-- レビューをする際に見てほしい点、ローカル環境で試す際の注意点、など -->
