### PR TITLE
Dockerのイメージとボリュームのタグにユーザ名を指定

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -27,25 +27,27 @@ type:
 
 run: format test-full type
 
+NAME=main
+
 docker-build: ## Build docker image.
-	docker build -t ami-vconf24 --no-cache .
+	docker build -t ami-vconf24:${NAME} --no-cache .
 
 docker-run: ## Run built docker image.
 	docker run -it --gpus all \
-	--mount type=volume,source=ami-vconf24,target=/workspace \
-	ami-vconf24
+	--mount type=volume,source=ami-vconf24_${NAME},target=/workspace \
+	ami-vconf24:${NAME}
 
 docker-run-host: ## Run the built Docker image along with network, camera, and other host OS device access
 	docker run -it --gpus all \
-	--mount type=volume,source=ami-vconf24,target=/workspace \
+	--mount type=volume,source=ami-vconf24_${NAME},target=/workspace \
 	--mount type=bind,source=`pwd`/logs,target=/workspace/logs \
 	--device `v4l2-ctl --list-devices | grep -A 1 'OBS Virtual Camera' | grep -oP '\t\K/dev.*'`:/dev/video0:mwr \
 	--net host \
-	ami-vconf24
+	ami-vconf24:${NAME}
 
 docker-run-unity: ## Run the built Docker image with Unity executables
 	docker run -it --gpus all \
-	--mount type=volume,source=ami-vconf24,target=/workspace \
+	--mount type=volume,source=ami-vconf24_${NAME},target=/workspace \
 	--mount type=bind,source=`pwd`/logs,target=/workspace/logs \
 	--mount type=bind,source=`pwd`/unity_executables,target=/workspace/unity_executables \
-	ami-vconf24
+	ami-vconf24:${NAME}

--- a/Makefile
+++ b/Makefile
@@ -27,27 +27,27 @@ type:
 
 run: format test-full type
 
-NAME=main
+NAME := $(shell whoami)
 
 docker-build: ## Build docker image.
-	docker build -t ami-vconf24:${NAME} --no-cache .
+	docker build -t ami-vconf24:$(NAME) --no-cache .
 
 docker-run: ## Run built docker image.
 	docker run -it --gpus all \
-	--mount type=volume,source=ami-vconf24_${NAME},target=/workspace \
-	ami-vconf24:${NAME}
+	--mount type=volume,source=ami-vconf24_$(NAME),target=/workspace \
+	ami-vconf24:$(NAME)
 
 docker-run-host: ## Run the built Docker image along with network, camera, and other host OS device access
 	docker run -it --gpus all \
-	--mount type=volume,source=ami-vconf24_${NAME},target=/workspace \
+	--mount type=volume,source=ami-vconf24_$(NAME),target=/workspace \
 	--mount type=bind,source=`pwd`/logs,target=/workspace/logs \
 	--device `v4l2-ctl --list-devices | grep -A 1 'OBS Virtual Camera' | grep -oP '\t\K/dev.*'`:/dev/video0:mwr \
 	--net host \
-	ami-vconf24:${NAME}
+	ami-vconf24:$(NAME)
 
 docker-run-unity: ## Run the built Docker image with Unity executables
 	docker run -it --gpus all \
-	--mount type=volume,source=ami-vconf24_${NAME},target=/workspace \
+	--mount type=volume,source=ami-vconf24_$(NAME),target=/workspace \
 	--mount type=bind,source=`pwd`/logs,target=/workspace/logs \
 	--mount type=bind,source=`pwd`/unity_executables,target=/workspace/unity_executables \
-	ami-vconf24:${NAME}
+	ami-vconf24:$(NAME)


### PR DESCRIPTION
## 概要

今まで`make docker-build`を実行すると既存のイメージを上書きしてしまったり、他のユーザと永続ボリュームが干渉してしまっていた。そのためユーザ名を取得し、それをタグやsuffixにすることによって解消した。

## Submit前の確認項目

<!-- PRをSubmitする前に確認する項目 -->

- [x] タイトルは一目でわかるようにし、説明文は PR を簡潔に説明するようにしましたか?
- [x] あなたの PR が、異なる変更を束ねたものではなく、ひとつのことだけを行うものであることを確認しましたか?
- [x] この PR で導入されたすべての変更点をリストアップしましたか?
- [x] PR を`make run`コマンドでローカルでテストしましたか?

## 補足

<!-- レビューをする際に見てほしい点、ローカル環境で試す際の注意点、など -->
