### PR TITLE
PolicyとValueが分離された場合の Curiosity Agentを実装

### DIFF
--- a/ami/interactions/agents/curiosity_image_ppo_agent.py
+++ b/ami/interactions/agents/curiosity_image_ppo_agent.py
@@ -220,7 +220,7 @@ class CuriosityImageSeparatePolicyValueAgent(BaseAgent[Tensor, Tensor]):
 
         action_dist: Distribution = self.policy_net(pv_obs, self.forward_dynamics_hidden_state)
         value_dist: Distribution = self.value_net(pv_obs, self.forward_dynamics_hidden_state)
-        action, value = action_dist.sample(), value_dist.sample()
+        action, value = action_dist.sample(), value_dist.sample().squeeze()
         action_log_prob = action_dist.log_prob(action)
 
         self.step_data[DataKeys.ACTION] = action  # a_t

--- a/ami/interactions/agents/curiosity_image_ppo_agent.py
+++ b/ami/interactions/agents/curiosity_image_ppo_agent.py
@@ -149,8 +149,8 @@ class CuriosityImagePPOAgent(BaseAgent[Tensor, Tensor]):
         self.forward_dynamics_hidden_state = torch.load(path / "forward_dynamics_hidden_state.pt", map_location="cpu")
 
 
-class CuriosityImageUnknownAgent(BaseAgent[Tensor, Tensor]):
-    """Image input curiosity agent with isolated policy and value network.
+class CuriosityImageSeparatePolicyValueAgent(BaseAgent[Tensor, Tensor]):
+    """Image input curiosity agent with separate policy and value network.
 
     And uses ForwardDynamicsWithActionReward
     """

--- a/ami/interactions/agents/curiosity_image_ppo_agent.py
+++ b/ami/interactions/agents/curiosity_image_ppo_agent.py
@@ -10,9 +10,10 @@ from ami.tensorboard_loggers import TimeIntervalLogger
 
 from ...data.buffers.buffer_names import BufferNames
 from ...data.step_data import DataKeys, StepData
-from ...models.forward_dynamics import ForwardDynamics
+from ...models.forward_dynamics import ForwardDynamcisWithActionReward, ForwardDynamics
 from ...models.model_names import ModelNames
 from ...models.model_wrapper import ThreadSafeInferenceWrapper
+from ...models.policy_or_value_network import PolicyOrValueNetwork
 from ...models.policy_value_common_net import PolicyValueCommonNet
 from .base_agent import BaseAgent
 
@@ -122,6 +123,115 @@ class CuriosityImagePPOAgent(BaseAgent[Tensor, Tensor]):
 
         pred, hidden = self.forward_dynamics(embed_obs, self.forward_dynamics_hidden_state, action)
         self.predicted_next_embed_observation_dist = pred  # p(\hat{z}_{t+1} | z_t, h_t, a_t)
+        self.forward_dynamics_hidden_state = hidden  # h_{t+1}
+
+        self.logger.update()
+
+        return action
+
+    def setup(self, observation: Tensor) -> Tensor:
+        super().setup(observation)
+
+        self.step_data = StepData()
+
+        return self._common_step(observation, initial_step=True)
+
+    def step(self, observation: Tensor) -> Tensor:
+        return self._common_step(observation, initial_step=False)
+
+    @override
+    def save_state(self, path: Path) -> None:
+        path.mkdir()
+        torch.save(self.forward_dynamics_hidden_state, path / "forward_dynamics_hidden_state.pt")
+
+    @override
+    def load_state(self, path: Path) -> None:
+        self.forward_dynamics_hidden_state = torch.load(path / "forward_dynamics_hidden_state.pt", map_location="cpu")
+
+
+class CuriosityImageUnknownAgent(BaseAgent[Tensor, Tensor]):
+    """Image input curiosity agent with isolated policy and value network.
+
+    And uses ForwardDynamicsWithActionReward
+    """
+
+    def __init__(
+        self,
+        initial_hidden: Tensor,
+        logger: TimeIntervalLogger,
+        reward: PredictionErrorReward,
+        use_embed_obs_for_policy_and_value: bool = True,  # 2024/07/30 default use embed observation.
+    ) -> None:
+        """Constructs Agent.
+
+        Args:
+            initial_hidden: Initial hidden state for the forward dynamics model.
+            use_embed_obs_for_policy_and_value: Use embed observation as observation for policy and value input.
+                Implemented for adapting the world models learning method.
+        """
+        super().__init__()
+
+        self.forward_dynamics_hidden_state = initial_hidden
+        self.logger = logger
+        self.reward_computer = reward
+        self.use_embed_obs_for_policy_and_value = use_embed_obs_for_policy_and_value
+
+    def on_inference_models_attached(self) -> None:
+        super().on_inference_models_attached()
+        self.image_encoder: ThreadSafeInferenceWrapper[nn.Module] = self.get_inference_model(ModelNames.IMAGE_ENCODER)
+        self.forward_dynamics: ThreadSafeInferenceWrapper[ForwardDynamcisWithActionReward] = self.get_inference_model(
+            ModelNames.FORWARD_DYNAMICS
+        )
+        self.policy_net: ThreadSafeInferenceWrapper[PolicyOrValueNetwork] = self.get_inference_model(ModelNames.POLICY)
+        self.value_net: ThreadSafeInferenceWrapper[PolicyOrValueNetwork] = self.get_inference_model(ModelNames.VALUE)
+
+    # ------ Interaction Process ------
+    predicted_next_embed_observation_dist: Distribution
+    predicted_reward_dist: Distribution
+    forward_dynamics_hidden_state: Tensor
+    step_data: StepData
+
+    def _common_step(self, observation: Tensor, initial_step: bool = False) -> Tensor:
+        """Common step procedure for agent.
+
+        If `initial_step` is False, some procedures are skipped.
+        """
+        # \phi(o_t) -> z_t
+        embed_obs = self.image_encoder(observation)
+
+        if not initial_step:
+            # 報酬計算は初期ステップではできないためスキップ。
+            reward = self.reward_computer.compute(self.predicted_next_embed_observation_dist, embed_obs)
+            self.step_data[DataKeys.REWARD] = reward  # r_{t+1}
+            self.logger.log("agent/reward", reward)
+            self.logger.log("agent/reward_negative_log_likelihood", -self.predicted_reward_dist.log_prob(reward).mean())
+
+            # ステップの冒頭でデータコレクトすることで前ステップのデータを収集する。
+            self.data_collectors.collect(self.step_data)
+
+        self.step_data[DataKeys.OBSERVATION] = observation  # o_t
+        self.step_data[DataKeys.EMBED_OBSERVATION] = embed_obs  # z_t
+
+        # Adaptiing World Models learning method.
+        if self.use_embed_obs_for_policy_and_value:
+            pv_obs = embed_obs
+        else:
+            pv_obs = observation
+
+        action_dist: Distribution = self.policy_net(pv_obs, self.forward_dynamics_hidden_state)
+        value_dist: Distribution = self.value_net(pv_obs, self.forward_dynamics_hidden_state)
+        action, value = action_dist.sample(), value_dist.sample()
+        action_log_prob = action_dist.log_prob(action)
+
+        self.step_data[DataKeys.ACTION] = action  # a_t
+        self.step_data[DataKeys.ACTION_LOG_PROBABILITY] = action_log_prob  # log \pi(a_t | o_t)
+        self.step_data[DataKeys.VALUE] = value  # v_t
+        self.step_data[DataKeys.HIDDEN] = self.forward_dynamics_hidden_state  # h_t
+        self.logger.log("agent/value", value.item())
+
+        pred_obs, _, pred_reward, hidden = self.forward_dynamics(embed_obs, self.forward_dynamics_hidden_state, action)
+        self.predicted_next_embed_observation_dist = pred_obs  # p(\hat{z}_{t+1} | z_t, h_t, a_t)
+        self.predicted_reward_dist = pred_reward  # p(\hat{r}_{t+1} | z_t, h_t, a_t)
         self.forward_dynamics_hidden_state = hidden  # h_{t+1}
 
         self.logger.update()

--- a/tests/interactions/agents/test_curiosity_image_ppo_agent.py
+++ b/tests/interactions/agents/test_curiosity_image_ppo_agent.py
@@ -8,9 +8,12 @@ from ami.data.utils import DataCollectorsDict
 from ami.interactions.agents.curiosity_image_ppo_agent import (
     BufferNames,
     CuriosityImagePPOAgent,
+    CuriosityImageSeparatePolicyValueAgent,
     DataKeys,
+    ForwardDynamcisWithActionReward,
     ForwardDynamics,
     ModelNames,
+    PolicyOrValueNetwork,
     PolicyValueCommonNet,
     PredictionErrorReward,
 )
@@ -136,6 +139,105 @@ class TestCuriosityImagePPOAgent:
         assert agent.step_data[DataKeys.REWARD].shape == ()
 
     def test_save_and_load_state(self, agent: CuriosityImagePPOAgent, tmp_path):
+        agent_path = tmp_path / "agent"
+        agent.save_state(agent_path)
+        assert (agent_path / "forward_dynamics_hidden_state.pt").exists()
+
+        hidden = agent.forward_dynamics_hidden_state.clone()
+        agent.forward_dynamics_hidden_state = torch.randn_like(hidden)
+        assert not torch.equal(agent.forward_dynamics_hidden_state, hidden)
+
+        agent.load_state(agent_path)
+        assert torch.equal(agent.forward_dynamics_hidden_state, hidden)
+
+
+class TestCuriosityImageSeparatePolicyValueAgent:
+    @pytest.fixture
+    def inference_models(self, device) -> InferenceWrappersDict:
+        image_encoder = SmallConvNet(WIDTH, HEIGHT, CHANNELS, EMBED_OBS_DIM)
+        forward_dynamics = ForwardDynamcisWithActionReward(
+            nn.Identity(),
+            nn.Identity(),
+            nn.Linear(EMBED_OBS_DIM + ACTION_DIM, SCONV_DIM),
+            SConv(DEPTH, SCONV_DIM, SCONV_DIM, 0.1),
+            FullyConnectedFixedStdNormal(SCONV_DIM, EMBED_OBS_DIM),
+            FullyConnectedFixedStdNormal(SCONV_DIM, ACTION_DIM),
+            FullyConnectedFixedStdNormal(SCONV_DIM, 1),
+        )
+
+        policy_net = PolicyOrValueNetwork(
+            nn.Identity(),
+            nn.Identity(),
+            SelectObservation(),
+            nn.Linear(EMBED_OBS_DIM, EMBED_OBS_DIM),
+            FullyConnectedFixedStdNormal(EMBED_OBS_DIM, ACTION_DIM),
+        )
+
+        value_net = PolicyOrValueNetwork(
+            nn.Identity(),
+            nn.Identity(),
+            SelectObservation(),
+            nn.Linear(EMBED_OBS_DIM, EMBED_OBS_DIM),
+            FullyConnectedFixedStdNormal(EMBED_OBS_DIM, 1),
+        )
+
+        mwd = ModelWrappersDict(
+            {
+                ModelNames.IMAGE_ENCODER: ModelWrapper(image_encoder, device, True),
+                ModelNames.FORWARD_DYNAMICS: ModelWrapper(forward_dynamics, device, True),
+                ModelNames.POLICY: ModelWrapper(policy_net, device, True),
+                ModelNames.VALUE: ModelWrapper(value_net, device, True),
+            }
+        )
+        mwd.send_to_default_device()
+
+        return mwd.inference_wrappers_dict
+
+    @pytest.fixture
+    def data_collectors(self) -> DataCollectorsDict:
+        empty_buffer = RandomDataBuffer(10, [DataKeys.OBSERVATION])
+        return DataCollectorsDict.from_data_buffers(
+            **{
+                BufferNames.IMAGE: empty_buffer,
+                BufferNames.DREAMING_INITIAL_STATES: empty_buffer,
+                BufferNames.FORWARD_DYNAMICS_TRAJECTORY: empty_buffer,
+            }
+        )
+
+    @pytest.fixture
+    def logger(self, tmp_path):
+        return TimeIntervalLogger(f"{tmp_path}/tensorboard", 0)
+
+    @pytest.fixture
+    def reward(self):
+        return PredictionErrorReward()
+
+    @pytest.fixture
+    def agent(self, inference_models, data_collectors, logger, reward) -> CuriosityImageSeparatePolicyValueAgent:
+        curiosity_agent = CuriosityImageSeparatePolicyValueAgent(torch.zeros(DEPTH, SCONV_DIM), logger, reward)
+        curiosity_agent.attach_data_collectors(data_collectors)
+        curiosity_agent.attach_inference_models(inference_models)
+        return curiosity_agent
+
+    def test_setup_step_teardown(self, agent: CuriosityImageSeparatePolicyValueAgent):
+        observation = torch.randn(CHANNELS, HEIGHT, WIDTH)
+        action = agent.setup(observation)
+
+        assert action.shape == (ACTION_DIM,)
+
+        for _ in range(10):
+            action = agent.step(observation)
+            assert action.shape == (ACTION_DIM,)
+
+        assert agent.step_data[DataKeys.OBSERVATION].shape == observation.shape
+        assert agent.step_data[DataKeys.EMBED_OBSERVATION].shape == (EMBED_OBS_DIM,)
+        assert agent.step_data[DataKeys.ACTION].shape == (ACTION_DIM,)
+        assert agent.step_data[DataKeys.ACTION_LOG_PROBABILITY].shape == (ACTION_DIM,)
+        assert agent.step_data[DataKeys.VALUE].shape == (1,)
+        assert agent.step_data[DataKeys.HIDDEN].shape == (DEPTH, SCONV_DIM)
+        assert agent.step_data[DataKeys.REWARD].shape == ()
+
+    def test_save_and_load_state(self, agent: CuriosityImageSeparatePolicyValueAgent, tmp_path):
         agent_path = tmp_path / "agent"
         agent.save_state(agent_path)
         assert (agent_path / "forward_dynamics_hidden_state.pt").exists()

--- a/tests/interactions/agents/test_curiosity_image_ppo_agent.py
+++ b/tests/interactions/agents/test_curiosity_image_ppo_agent.py
@@ -233,7 +233,7 @@ class TestCuriosityImageSeparatePolicyValueAgent:
         assert agent.step_data[DataKeys.EMBED_OBSERVATION].shape == (EMBED_OBS_DIM,)
         assert agent.step_data[DataKeys.ACTION].shape == (ACTION_DIM,)
         assert agent.step_data[DataKeys.ACTION_LOG_PROBABILITY].shape == (ACTION_DIM,)
-        assert agent.step_data[DataKeys.VALUE].shape == (1,)
+        assert agent.step_data[DataKeys.VALUE].shape == ()
         assert agent.step_data[DataKeys.HIDDEN].shape == (DEPTH, SCONV_DIM)
         assert agent.step_data[DataKeys.REWARD].shape == ()
 


### PR DESCRIPTION
## 概要

#18 CuriosityPPOAgentを拡張しようかと思いましたが下手にコードを汚くするのでとりあえずコピペして、Forward Dynamics With Action Reward, Policy, Valueを使うAgentを実装しました。
コードの内容の関連性的に`curiosity_ppo_agent.py`に配置しています。将来的にうまく統合できたらします。

## 変更内容

<!-- ビューの変更がある場合はスクショによる比較などがあるとわかりやすい -->

## 影響範囲

<!-- この関数を変更したのでこの機能にも影響がある、など -->

## Submit前の確認項目

<!-- PRをSubmitする前に確認する項目 -->

- [x] タイトルは一目でわかるようにし、説明文は PR を簡潔に説明するようにしましたか?
- [x] あなたの PR が、異なる変更を束ねたものではなく、ひとつのことだけを行うものであることを確認しましたか?
- [x] この PR で導入されたすべての変更点をリストアップしましたか?
- [x] PR を`make run`コマンドでローカルでテストしましたか?

## 補足

<!-- レビューをする際に見てほしい点、ローカル環境で試す際の注意点、など -->
