### PR TITLE
DistributionHeadクラスに `squeeze_feature_dim`のoptionを追加

### DIFF
--- a/ami/models/components/fully_connected_fixed_std_normal.py
+++ b/ami/models/components/fully_connected_fixed_std_normal.py
@@ -16,14 +16,26 @@ class FullyConnectedFixedStdNormal(nn.Module):
     https://github.com/MLShukai/ami/issues/117
     """
 
-    def __init__(self, dim_in: int, dim_out: int, std: float = SHIFT_ZERO, normal_cls: type[Normal] = Normal) -> None:
+    def __init__(
+        self,
+        dim_in: int,
+        dim_out: int,
+        std: float = SHIFT_ZERO,
+        normal_cls: type[Normal] = Normal,
+        squeeze_feature_dim: bool = False,
+    ) -> None:
         super().__init__()
+        if squeeze_feature_dim:
+            assert dim_out == 1, "Can not squeeze feature dimension!"
         self.fc = nn.Linear(dim_in, dim_out)
         self.std = std
         self.normal_cls = normal_cls
+        self.squeeze_feature_dim = squeeze_feature_dim
 
     def forward(self, x: Tensor) -> Normal:
-        mean = self.fc(x)
+        mean: Tensor = self.fc(x)
+        if self.squeeze_feature_dim:
+            mean = mean.squeeze(-1)
         std = torch.full_like(mean, self.std)
         return self.normal_cls(mean, std)
 

--- a/ami/models/components/fully_connected_normal.py
+++ b/ami/models/components/fully_connected_normal.py
@@ -6,13 +6,20 @@ from torch.distributions import Normal
 class FullyConnectedNormal(nn.Module):
     """The layer which returns the normal distribution."""
 
-    def __init__(self, dim_in: int, dim_out: int, eps: float = 1e-6) -> None:
+    def __init__(self, dim_in: int, dim_out: int, eps: float = 1e-6, squeeze_feature_dim: bool = False) -> None:
         super().__init__()
+        if squeeze_feature_dim:
+            assert dim_out == 1, "Can not squeeze feature dimension!"
+
         self.fc_mean = nn.Linear(dim_in, dim_out)
         self.fc_std = nn.Linear(dim_in, dim_out)
         self.eps = eps
+        self.squeeze_feature_dim = squeeze_feature_dim
 
     def forward(self, x: Tensor) -> Normal:
-        mean = self.fc_mean(x)
-        std = nn.functional.softplus(self.fc_std(x)) + self.eps
+        mean: Tensor = self.fc_mean(x)
+        std: Tensor = nn.functional.softplus(self.fc_std(x)) + self.eps
+        if self.squeeze_feature_dim:
+            mean = mean.squeeze(-1)
+            std = std.squeeze(-1)
         return Normal(mean, std)

--- a/tests/models/components/test_fully_connected_fixed_std_normal.py
+++ b/tests/models/components/test_fully_connected_fixed_std_normal.py
@@ -1,3 +1,4 @@
+import pytest
 import torch
 from torch.distributions import Normal
 
@@ -49,6 +50,19 @@ class TestFullyConnectedFixedStdNormal:
         assert out.sample().shape == (20,)
 
         assert layer(torch.randn(1, 2, 3, 10)).sample().shape == (1, 2, 3, 20)
+
+    def test_squeeze_feature_dim(self):
+        with pytest.raises(AssertionError):
+            # out_features must be 1.
+            FullyConnectedFixedStdNormal(10, 2, squeeze_feature_dim=True)
+
+        # `squeeze_feature_dim` default false.
+        FullyConnectedFixedStdNormal(10, 2)
+
+        net = FullyConnectedFixedStdNormal(10, 1, squeeze_feature_dim=True)
+        x = torch.randn(10)
+        out = net(x)
+        assert out.sample().shape == ()
 
 
 class TestDeterministicNormal:

--- a/tests/models/components/test_fully_connected_normal.py
+++ b/tests/models/components/test_fully_connected_normal.py
@@ -12,3 +12,16 @@ class TestFullyConnectedNormal:
         out = m(data)
         assert isinstance(out, Normal)
         assert out.rsample().shape == (batch_size, dim_out)
+
+    def test_squeeze_feature_dim(self):
+        with pytest.raises(AssertionError):
+            # out_features must be 1.
+            FullyConnectedNormal(10, 2, squeeze_feature_dim=True)
+
+        # `squeeze_feature_dim` default false.
+        FullyConnectedNormal(10, 2)
+
+        net = FullyConnectedNormal(10, 1, squeeze_feature_dim=True)
+        x = torch.randn(10)
+        out = net(x)
+        assert out.sample().shape == ()

--- a/tests/models/components/test_mixture_density_network.py
+++ b/tests/models/components/test_mixture_density_network.py
@@ -99,3 +99,17 @@ class TestNormalMixtureDensityNetwork:
         # Check that gradients are computed
         assert x.grad is not None
         assert output.sample().grad is None
+
+    def test_squeeze_feature_dim(self):
+        with pytest.raises(AssertionError):
+            # out_features must be 1.
+            NormalMixtureDensityNetwork(10, 2, 3, squeeze_feature_dim=True)
+
+        # `squeeze_feature_dim` default false.
+        NormalMixtureDensityNetwork(10, 2, 3)
+
+        # check squeezing.
+        net = NormalMixtureDensityNetwork(10, 1, 3, squeeze_feature_dim=True)
+        x = torch.randn(10)
+        out = net(x)
+        assert out.sample().shape == ()


### PR DESCRIPTION
## 概要

RewardやValue Headを予測する際に scalar次元であることが実装上求められるため、出力ヘッドの特徴量次元をsqueezeできる機能を実装した。特別にDistribution型を出力するレイヤーに対して適用したのは、Tensorが出力ではないため`forward`のoutputに対して行う操作が一律同じではなく、`squeeze`を内部的に実行しなければならないためである。


## Submit前の確認項目

<!-- PRをSubmitする前に確認する項目 -->

- [x] タイトルは一目でわかるようにし、説明文は PR を簡潔に説明するようにしましたか?
- [x] あなたの PR が、異なる変更を束ねたものではなく、ひとつのことだけを行うものであることを確認しましたか?
- [x] この PR で導入されたすべての変更点をリストアップしましたか?
- [x] PR を`make run`コマンドでローカルでテストしましたか?

## 補足

<!-- レビューをする際に見てほしい点、ローカル環境で試す際の注意点、など -->
