### PR TITLE
Dreamerの学習時に予測の温度パラメータを指定可能に

### DIFF
--- a/configs/trainers/dreaming_policy_value/default.yaml
+++ b/configs/trainers/dreaming_policy_value/default.yaml
@@ -27,5 +27,6 @@ logger:
 device: ${devices.0}
 max_epochs: 1
 imagination_trajectory_length: 25
+imagination_temperature: 1.0
 minimum_dataset_size: ${.partial_dataloader.batch_size}
 minimum_new_data_count: ${.partial_dataloader.batch_size}

--- a/tests/models/components/test_mixture_density_network.py
+++ b/tests/models/components/test_mixture_density_network.py
@@ -14,12 +14,12 @@ class TestNormalMixture:
     @pytest.mark.parametrize("num_components", [2, 3])
     def test_normal_mixture(self, batch_shape, num_components):
         # Create test data
-        log_pi = torch.randn(*batch_shape, num_components).log_softmax(-1)
+        logits = torch.randn(*batch_shape, num_components)
         mu = torch.randn(*batch_shape, num_components)
         sigma = torch.rand(*batch_shape, num_components).add_(0.1)  # Ensure positive values
 
         # Create NormalMixture instance
-        mixture = NormalMixture(log_pi, mu, sigma)
+        mixture = NormalMixture(logits, mu, sigma)
 
         # Test batch_shape
         assert mixture.batch_shape == torch.Size(batch_shape)
@@ -41,18 +41,22 @@ class TestNormalMixture:
         rsample = mixture.rsample()
         assert rsample.shape == torch.Size(batch_shape)
 
+        # Test temperature sample
+        assert mixture.rsample(temperature=10.0).shape == torch.Size(batch_shape)
+        assert mixture.sample(temperature=0.1).shape == torch.Size(batch_shape)
+
         # Test consistency with individual normal components
         components = [Normal(mu[..., i], sigma[..., i]) for i in range(num_components)]
         mixture_log_prob = mixture.log_prob(sample)
         component_log_probs = torch.stack([comp.log_prob(sample) for comp in components], dim=-1)
-        component_log_probs += log_pi
+        component_log_probs += logits.log_softmax(-1)
         expected_log_prob = torch.logsumexp(component_log_probs, dim=-1)
         assert torch.allclose(mixture_log_prob, expected_log_prob, atol=1e-5)
 
     def test_normal_mixture_invalid_args(self):
         # Test error handling for invalid arguments
         with pytest.raises(AssertionError):
-            NormalMixture(torch.randn(3, 2), torch.randn(3, 3), torch.rand(3, 2).add_(0.1))
+            NormalMixture(torch.randn(3, 2), torch.randn(3, 3), -torch.ones(3, 2))
 
 
 class TestNormalMixtureDensityNetwork:
@@ -76,6 +80,7 @@ class TestNormalMixtureDensityNetwork:
         # Check output shapes
         assert output.batch_shape == torch.Size([batch_size, out_features])
         assert output.event_shape == torch.Size([])
+        assert output.logits.shape == (batch_size, out_features, num_components)
         assert output.log_pi.shape == (batch_size, out_features, num_components)
         assert output.mu.shape == (batch_size, out_features, num_components)
         assert output.sigma.shape == (batch_size, out_features, num_components)


### PR DESCRIPTION
## 概要

#44 NormalMixtureが log_piを受け取る実装だと温度パラメータを動的に変更できないのでそこの仕様変更もしました。

## Submit前の確認項目

<!-- PRをSubmitする前に確認する項目 -->

- [x] タイトルは一目でわかるようにし、説明文は PR を簡潔に説明するようにしましたか?
- [x] あなたの PR が、異なる変更を束ねたものではなく、ひとつのことだけを行うものであることを確認しましたか?
- [x] この PR で導入されたすべての変更点をリストアップしましたか?
- [x] PR を`make run`コマンドでローカルでテストしましたか?

## 補足

<!-- レビューをする際に見てほしい点、ローカル環境で試す際の注意点、など -->
