### PR TITLE
Model Namesでモデルにアクセスする際のエイリアス機能を実装

### DIFF
--- a/ami/hydra_instantiators.py
+++ b/ami/hydra_instantiators.py
@@ -31,15 +31,17 @@ def instantiate_data_collectors(data_collectors_cfg: DictConfig) -> DataCollecto
 def instantiate_models(models_cfg: DictConfig) -> ModelWrappersDict:
     d = ModelWrappersDict()
     aliases = []
-    for name, cfg in models_cfg.items():
-        match cfg:
+    for name, cfg_or_alias_target in models_cfg.items():
+        match cfg_or_alias_target:
             case DictConfig():
+                cfg = cfg_or_alias_target
                 logger.info(f"Instantiating <{cfg._target_}[{cfg.model._target_}]>")
                 model_wrapper: ModelWrapper[Any] = hydra.utils.instantiate(cfg)
                 d[ModelNames(str(name))] = model_wrapper
             case str():
-                logger.info(f"Model name {name!r} is alias to {cfg!r}")
-                aliases.append((name, cfg))
+                target = cfg_or_alias_target
+                logger.info(f"Model name {name!r} is alias to {target!r}")
+                aliases.append((name, target))
             case _:
                 raise RuntimeError(f"Model config or alias must be DictConfig or str! {cfg}")
     for alias, target in aliases:

--- a/ami/models/model_wrapper.py
+++ b/ami/models/model_wrapper.py
@@ -92,7 +92,19 @@ class ModelWrapper(nn.Module, Generic[ModuleType]):
             p.requires_grad = True
         self.train()
 
-    def create_inference(self) -> ThreadSafeInferenceWrapper[ModuleType]:
+    _inference_wrapper: ThreadSafeInferenceWrapper[ModuleType] | None = None
+
+    @property
+    def inference_wrapper(self) -> ThreadSafeInferenceWrapper[ModuleType]:
+        """Returns the inference wrapper.
+
+        NOTE: Returns a reference to the existing instance if it has already been created.
+        """
+        if self._inference_wrapper is None:
+            self._inference_wrapper = self._create_inference()
+        return self._inference_wrapper
+
+    def _create_inference(self) -> ThreadSafeInferenceWrapper[ModuleType]:
         """Creates the inference wrapper for the inference thread.
 
         Do not call when the model wrapper has no inference model.

--- a/ami/models/utils.py
+++ b/ami/models/utils.py
@@ -92,7 +92,7 @@ class ModelWrappersDict(UserDict[str, ModelWrapper[nn.Module]], SaveAndLoadState
 
     @override
     def __delitem__(self, key: str) -> None:
-        raise RuntimeError(f"Deleting item is prohibited due to the presence of alias keys! Key:{key!r}")
+        raise RuntimeError(f"Deleting item is prohibited! Key:{key!r}")
 
 
 def count_model_parameters(model: nn.Module) -> tuple[int, int, int]:

--- a/tests/models/test_model_wrapper.py
+++ b/tests/models/test_model_wrapper.py
@@ -22,10 +22,11 @@ class TestWrappers:
         m.to_default_device()
         assert m.device == gpu_device
 
-    def test_create_inference(self):
+    def test_inference_wrapper_property(self):
         m = ModelMultiplyP()
         mw = ModelWrapper(m, "cpu", True)
-        inference_wrapper = mw.create_inference()
+        inference_wrapper = mw.inference_wrapper
+        assert mw.inference_wrapper is inference_wrapper
         assert isinstance(inference_wrapper, ThreadSafeInferenceWrapper)
         assert inference_wrapper.model is not m
         assert inference_wrapper.model.p is not m.p
@@ -33,12 +34,12 @@ class TestWrappers:
 
         mw = ModelWrapper(m, "cpu", False)
         with pytest.raises(RuntimeError):
-            mw.create_inference()
+            mw.inference_wrapper
 
     def test_infer_cpu(self):
         mw = ModelWrapper(ModelMultiplyP(), "cpu", True)
         mw.to_default_device()
-        inference = mw.create_inference()
+        inference = mw.inference_wrapper
 
         data = torch.randn(10)
         assert isinstance(inference(data), torch.Tensor)
@@ -47,7 +48,7 @@ class TestWrappers:
     def test_infer_gpu(self, gpu_device: torch.device):
         mw = ModelWrapper(ModelMultiplyP(), gpu_device, True)
         mw.to_default_device()
-        inference = mw.create_inference()
+        inference = mw.inference_wrapper
 
         data = torch.randn(10)
         out: torch.Tensor = inference(data)

--- a/tests/models/test_vae.py
+++ b/tests/models/test_vae.py
@@ -65,7 +65,7 @@ class TestEncoderWrapper:
         return encoder_wrapper
 
     def test__inference(self, encoder_wrapper):
-        inference = encoder_wrapper.create_inference()
+        inference = encoder_wrapper.inference_wrapper
         x = torch.randn(16, CHANNELS, HEIGHT, WIDTH)
         z = inference(x)
         assert z.size() == (16, DIM_EMBED)

--- a/tests/test_hydra_instantiators.py
+++ b/tests/test_hydra_instantiators.py
@@ -1,37 +1,40 @@
+import pytest
+from omegaconf import OmegaConf
+
 from ami.hydra_instantiators import instantiate_models
 from ami.models.model_names import ModelNames
-from omegaconf import OmegaConf
-import pytest
 
 
 def test_instantiate_models():
-    # Test instantiate 
-    cfg = OmegaConf.create("""\
-    image_decoder:
-      _target_: ami.models.model_wrapper.ModelWrapper
-      model:
-        _target_: ami.models.vae.Conv2dDecoder
-        height: 84
-        width: 84
-        channels: 3
-        latent_dim: 512
-    """
+    # Test instantiate
+    cfg = OmegaConf.create(
+        """\
+        image_decoder:
+          _target_: ami.models.model_wrapper.ModelWrapper
+          model:
+            _target_: ami.models.vae.Conv2dDecoder
+            height: 84
+            width: 84
+            channels: 3
+            latent_dim: 512
+        """
     )
     models = instantiate_models(cfg)
     assert ModelNames.IMAGE_DECODER in models
 
     # Test alias
-    cfg = OmegaConf.create("""\
-    image_decoder:
-      _target_: ami.models.model_wrapper.ModelWrapper
-      model:
-        _target_: ami.models.vae.Conv2dDecoder
-        height: 84
-        width: 84
-        channels: 3
-        latent_dim: 512
-    image_encoder: image_decoder
-    """
+    cfg = OmegaConf.create(
+        """\
+        image_decoder:
+          _target_: ami.models.model_wrapper.ModelWrapper
+          model:
+            _target_: ami.models.vae.Conv2dDecoder
+            height: 84
+            width: 84
+            channels: 3
+            latent_dim: 512
+        image_encoder: image_decoder
+        """
     )
     models = instantiate_models(cfg)
     assert ModelNames.IMAGE_DECODER in models
@@ -39,17 +42,18 @@ def test_instantiate_models():
     assert models[ModelNames.IMAGE_ENCODER] is models[ModelNames.IMAGE_DECODER]
 
     # Test invalid config format
-    cfg = OmegaConf.create("""\
-    image_decoder:
-        _target_: ami.models.model_wrapper.ModelWrapper
-        model:
-          _target_: ami.models.vae.Conv2dDecoder
-          height: 84
-          width: 84
-          channels: 3
-          latent_dim: 512
-    image_encoder: 0 # <- not str value is allowed!
-    """
+    cfg = OmegaConf.create(
+        """\
+        image_decoder:
+            _target_: ami.models.model_wrapper.ModelWrapper
+            model:
+              _target_: ami.models.vae.Conv2dDecoder
+              height: 84
+              width: 84
+              channels: 3
+              latent_dim: 512
+        image_encoder: 0 # <- not str value is allowed!
+        """
     )
     with pytest.raises(RuntimeError):
-      instantiate_models(cfg)
+        instantiate_models(cfg)

--- a/tests/test_hydra_instantiators.py
+++ b/tests/test_hydra_instantiators.py
@@ -1,0 +1,55 @@
+from ami.hydra_instantiators import instantiate_models
+from ami.models.model_names import ModelNames
+from omegaconf import OmegaConf
+import pytest
+
+
+def test_instantiate_models():
+    # Test instantiate 
+    cfg = OmegaConf.create("""\
+    image_decoder:
+      _target_: ami.models.model_wrapper.ModelWrapper
+      model:
+        _target_: ami.models.vae.Conv2dDecoder
+        height: 84
+        width: 84
+        channels: 3
+        latent_dim: 512
+    """
+    )
+    models = instantiate_models(cfg)
+    assert ModelNames.IMAGE_DECODER in models
+
+    # Test alias
+    cfg = OmegaConf.create("""\
+    image_decoder:
+      _target_: ami.models.model_wrapper.ModelWrapper
+      model:
+        _target_: ami.models.vae.Conv2dDecoder
+        height: 84
+        width: 84
+        channels: 3
+        latent_dim: 512
+    image_encoder: image_decoder
+    """
+    )
+    models = instantiate_models(cfg)
+    assert ModelNames.IMAGE_DECODER in models
+    assert ModelNames.IMAGE_ENCODER in models
+    assert models[ModelNames.IMAGE_ENCODER] is models[ModelNames.IMAGE_DECODER]
+
+    # Test invalid config format
+    cfg = OmegaConf.create("""\
+    image_decoder:
+        _target_: ami.models.model_wrapper.ModelWrapper
+        model:
+          _target_: ami.models.vae.Conv2dDecoder
+          height: 84
+          width: 84
+          channels: 3
+          latent_dim: 512
+    image_encoder: 0 # <- not str value is allowed!
+    """
+    )
+    with pytest.raises(RuntimeError):
+      instantiate_models(cfg)


### PR DESCRIPTION
## 概要

I-JEPAなどの実装において、同一のモデルを別名で参照可能にする必要が発生したため、 モデルをInstantiateする際にエイリアスネームを設定可能にしました。
特に、`I_JEPA_TARGET_ENCODER`を、`IMAGE_ENCODER`という名前でアクセスする際に役立ちます。
片方は`Trainer`から、 片方は `Agent`クラスから参照されるときの名前です。

このような形で記述します。
```yaml
i_iepa_target_encoder:
  _target_: ami.models.model_wrapper.ModelWrapper
  model:
    _target_: ami.models.vae.Conv2dDecoder
    height: 84
    width: 84
    channels: 3
    latent_dim: 512

image_encoder: i_iepa_target_encoder # Alias
```

## 変更内容

その関係で、 InferenceWrapperを ModelWrapperに対してシングルトン化しました。これにより、InferenceWrappersDictでも同一のエイリアスが効くようになります。

ModelWrappersDictのキー上書き・削除操作を禁じました。エイリアスを作成する都合上、問題となるためです。

## Submit前の確認項目

<!-- PRをSubmitする前に確認する項目 -->

- [x] タイトルは一目でわかるようにし、説明文は PR を簡潔に説明するようにしましたか?
- [x] あなたの PR が、異なる変更を束ねたものではなく、ひとつのことだけを行うものであることを確認しましたか?
- [x] この PR で導入されたすべての変更点をリストアップしましたか?
- [x] PR を`make run`コマンドでローカルでテストしましたか?

## 補足

<!-- レビューをする際に見てほしい点、ローカル環境で試す際の注意点、など -->
