### PR TITLE
ImageFolderObservationGeneratorを作成

### DIFF
--- a/ami/interactions/environments/image_folder_observation_generator.py
+++ b/ami/interactions/environments/image_folder_observation_generator.py
@@ -1,0 +1,49 @@
+import random
+from pathlib import Path
+
+import torch
+from torchvision.datasets import ImageFolder
+from torchvision.transforms.functional import pil_to_tensor, resize
+
+
+class ImageFolderObservationGenerator:
+    """This class reads the images from folder and provides the tensor
+    observation for `DummyEnvironment` class."""
+
+    def __init__(
+        self,
+        root_dir: str | Path,
+        image_size: tuple[int, int],
+        divide_255: bool = True,
+        dtype: torch.dtype = torch.float,
+    ) -> None:
+        """Initialize the ImageFolderObservationGenerator.
+
+        Args:
+            root_dir (str | Path): The root directory containing the image folders.
+            image_size (tuple[int, int]): Target image size. height and width.
+            divide_255 (bool, optional): Whether to divide pixel values by 255. Defaults to True.
+            dtype (torch.dtype, optional): The desired data type of the output tensor. Defaults to torch.float.
+        """
+        self.image_size = image_size
+        self.divide_255 = divide_255
+        self.dtype = dtype
+
+        self._dataset = ImageFolder(root_dir)
+
+    def __call__(self) -> torch.Tensor:
+        """Returns the random sampled image.
+
+        Returns:
+            torch.Tensor: A tensor representing a randomly sampled image from the dataset,
+                          resized to the specified image_size, with optional normalization,
+                          and converted to the specified dtype.
+        """
+        i = random.randrange(len(self._dataset))
+        pil_img, _ = self._dataset[i]
+        img = pil_to_tensor(pil_img)
+        img = resize(img, self.image_size)
+        if self.divide_255:
+            img = img / 255
+        img = img.type(self.dtype)
+        return img

--- a/ami/interactions/environments/image_folder_observation_generator.py
+++ b/ami/interactions/environments/image_folder_observation_generator.py
@@ -3,7 +3,7 @@ from pathlib import Path
 
 import torch
 from torchvision.datasets import ImageFolder
-from torchvision.transforms.functional import pil_to_tensor, resize
+from torchvision.transforms import v2
 
 
 class ImageFolderObservationGenerator:
@@ -14,36 +14,35 @@ class ImageFolderObservationGenerator:
         self,
         root_dir: str | Path,
         image_size: tuple[int, int],
-        divide_255: bool = True,
-        dtype: torch.dtype = torch.float,
+        transform: v2.Transform | None = None,
     ) -> None:
         """Initialize the ImageFolderObservationGenerator.
 
         Args:
             root_dir (str | Path): The root directory containing the image folders.
             image_size (tuple[int, int]): Target image size. height and width.
-            divide_255 (bool, optional): Whether to divide pixel values by 255. Defaults to True.
-            dtype (torch.dtype, optional): The desired data type of the output tensor. Defaults to torch.float.
+            transform (v2.Transform | None, optional): Custom transform to be applied to the images.
+                If None, a default transform will be used. Defaults to None.
         """
         self.image_size = image_size
-        self.divide_255 = divide_255
-        self.dtype = dtype
+        if transform is None:
+            transform = v2.Compose(
+                [
+                    v2.ToImage(),
+                    v2.ToDtype(torch.float, scale=True),
+                ]
+            )
 
-        self._dataset = ImageFolder(root_dir)
+        self._dataset = ImageFolder(root_dir, transform)
 
     def __call__(self) -> torch.Tensor:
-        """Returns the random sampled image.
+        """Returns a random sampled image.
 
         Returns:
             torch.Tensor: A tensor representing a randomly sampled image from the dataset,
-                          resized to the specified image_size, with optional normalization,
-                          and converted to the specified dtype.
+                          resized to the specified image_size, with applied transformations.
         """
         i = random.randrange(len(self._dataset))
-        pil_img, _ = self._dataset[i]
-        img = pil_to_tensor(pil_img)
-        img = resize(img, self.image_size)
-        if self.divide_255:
-            img = img / 255
-        img = img.type(self.dtype)
+        img, _ = self._dataset[i]
+        img = v2.functional.resize(img, self.image_size)
         return img

--- a/tests/interactions/environments/test_image_folder_observation_generator.py
+++ b/tests/interactions/environments/test_image_folder_observation_generator.py
@@ -1,7 +1,10 @@
+from pathlib import Path
+
 import numpy as np
 import pytest
 import torch
 from PIL import Image
+from torchvision.transforms import v2
 
 from ami.interactions.environments.image_folder_observation_generator import (
     ImageFolderObservationGenerator,
@@ -22,24 +25,27 @@ def sample_image_folder(tmp_path):
 
 
 class TestImageFolderObservationGenerator:
-    def test_divide_255(self, sample_image_folder):
-        generator = ImageFolderObservationGenerator(sample_image_folder, (64, 64), divide_255=True)
+    def test_custom_transform(self, sample_image_folder):
+        custom_transform = v2.Compose(
+            [
+                v2.ToImage(),
+                v2.ToDtype(torch.uint8, scale=True),
+            ]
+        )
+        generator = ImageFolderObservationGenerator(sample_image_folder, (64, 64), transform=custom_transform)
         result = generator()
-        assert torch.all(result >= 0) and torch.all(result <= 1)
-
-    def test_no_divide_255(self, sample_image_folder):
-        generator = ImageFolderObservationGenerator(sample_image_folder, (64, 64), divide_255=False)
-        result = generator()
-        assert torch.any(result > 1)  # At least some values should be > 1 if not divided by 255
-
-    @pytest.mark.parametrize("dtype", [torch.int, torch.double, torch.cfloat])
-    def test_custom_dtype(self, sample_image_folder, dtype):
-        generator = ImageFolderObservationGenerator(sample_image_folder, (64, 64), dtype=dtype)
-        result = generator()
-        assert result.dtype == dtype
+        assert result.shape == (3, 64, 64)
+        assert result.dtype == torch.uint8
 
     @pytest.mark.parametrize("image_size", [(50, 50), (100, 150), (224, 224)])
-    def test_resize(self, sample_image_folder, image_size):
+    def test_various_image_sizes(self, sample_image_folder, image_size):
         generator = ImageFolderObservationGenerator(sample_image_folder, image_size)
         result = generator()
         assert result.shape == (3, *image_size)
+
+    def test_default_transform(self, sample_image_folder):
+        generator = ImageFolderObservationGenerator(sample_image_folder, (64, 64))
+        result = generator()
+        assert isinstance(result, torch.Tensor)
+        assert result.dtype == torch.float
+        assert torch.all(result >= 0) and torch.all(result <= 1)

--- a/tests/interactions/environments/test_image_folder_observation_generator.py
+++ b/tests/interactions/environments/test_image_folder_observation_generator.py
@@ -1,0 +1,45 @@
+import numpy as np
+import pytest
+import torch
+from PIL import Image
+
+from ami.interactions.environments.image_folder_observation_generator import (
+    ImageFolderObservationGenerator,
+)
+
+
+@pytest.fixture
+def sample_image_folder(tmp_path):
+    folder = tmp_path / "sample_images"
+    folder.mkdir()
+    subfolders = ["class1", "class2"]
+    for subfolder in subfolders:
+        (folder / subfolder).mkdir()
+        for i in range(2):
+            img = Image.fromarray(np.random.randint(0, 255, (100, 100, 3), dtype=np.uint8))
+            img.save(folder / subfolder / f"image_{i}.jpg")
+    return folder
+
+
+class TestImageFolderObservationGenerator:
+    def test_divide_255(self, sample_image_folder):
+        generator = ImageFolderObservationGenerator(sample_image_folder, (64, 64), divide_255=True)
+        result = generator()
+        assert torch.all(result >= 0) and torch.all(result <= 1)
+
+    def test_no_divide_255(self, sample_image_folder):
+        generator = ImageFolderObservationGenerator(sample_image_folder, (64, 64), divide_255=False)
+        result = generator()
+        assert torch.any(result > 1)  # At least some values should be > 1 if not divided by 255
+
+    @pytest.mark.parametrize("dtype", [torch.int, torch.double, torch.cfloat])
+    def test_custom_dtype(self, sample_image_folder, dtype):
+        generator = ImageFolderObservationGenerator(sample_image_folder, (64, 64), dtype=dtype)
+        result = generator()
+        assert result.dtype == dtype
+
+    @pytest.mark.parametrize("image_size", [(50, 50), (100, 150), (224, 224)])
+    def test_resize(self, sample_image_folder, image_size):
+        generator = ImageFolderObservationGenerator(sample_image_folder, image_size)
+        result = generator()
+        assert result.shape == (3, *image_size)


### PR DESCRIPTION
## 概要

#52 I-JEPAのテスト用のObservationGeneratorクラスを作成しました。
#51 で作成されている experiment config をオーバライドしたexperiment configファイルを作ると良いです。

```yaml
# @package _global_

defaults:
  - i_jepa
  - override /interaction/environment: dummy_image_io

interaction:
  environment:
    observation_generator: 
      _target_: ami.interactions.environments.image_folder_observation_generator.ImageFolderObservationGenerator
      root_dir: ${image_data_dir}

image_data_dir: ??? # Specify as command line argument. `python launch.py experiment=<experiment file name> image_data_dir=<path/to/image_data>
task_name: i_jepa_with_dataset
```
## Submit前の確認項目

<!-- PRをSubmitする前に確認する項目 -->

- [x] タイトルは一目でわかるようにし、説明文は PR を簡潔に説明するようにしましたか?
- [x] あなたの PR が、異なる変更を束ねたものではなく、ひとつのことだけを行うものであることを確認しましたか?
- [x] この PR で導入されたすべての変更点をリストアップしましたか?
- [x] PR を`make run`コマンドでローカルでテストしましたか?

## 補足

<!-- レビューをする際に見てほしい点、ローカル環境で試す際の注意点、など -->
