### PR TITLE
長期的な予測誤差も用いるAgentの実装

### DIFF
--- a/ami/interactions/agents/multi_step_imagination_curiosity_agent.py
+++ b/ami/interactions/agents/multi_step_imagination_curiosity_agent.py
@@ -1,0 +1,145 @@
+from pathlib import Path
+
+import torch
+import torch.nn as nn
+from torch import Tensor
+from torch.distributions import Distribution
+from typing_extensions import override
+
+from ami.tensorboard_loggers import TimeIntervalLogger
+
+from ...data.step_data import DataKeys, StepData
+from ...models.forward_dynamics import ForwardDynamcisWithActionReward
+from ...models.model_names import ModelNames
+from ...models.model_wrapper import ThreadSafeInferenceWrapper
+from ...models.policy_or_value_network import PolicyOrValueNetwork
+from .base_agent import BaseAgent
+from .curiosity_image_ppo_agent import PredictionErrorReward
+
+
+class MultiStepImaginationCuriosityImageAgent(BaseAgent[Tensor, Tensor]):
+    def __init__(
+        self,
+        initial_hidden: Tensor,
+        logger: TimeIntervalLogger,
+        max_imagination_steps: int = 1,
+        reward_scale: float = 1.0,
+        reward_shift: float = 0.0,
+    ) -> None:
+        """Constructs Agent.
+
+        Args:
+            initial_hidden: Initial hidden state for the forward dynamics model.
+            max_imagination_steps: Max step for imagination.
+        """
+        super().__init__()
+        assert max_imagination_steps > 0
+
+        self.exact_forward_dynamics_hidden_state = initial_hidden
+        self.logger = logger
+        self.reward_computer = PredictionErrorReward(reward_scale, reward_shift)
+        self.max_imagination_steps = max_imagination_steps
+
+    def on_inference_models_attached(self) -> None:
+        super().on_inference_models_attached()
+        self.image_encoder: ThreadSafeInferenceWrapper[nn.Module] = self.get_inference_model(ModelNames.IMAGE_ENCODER)
+        self.forward_dynamics: ThreadSafeInferenceWrapper[ForwardDynamcisWithActionReward] = self.get_inference_model(
+            ModelNames.FORWARD_DYNAMICS
+        )
+        self.policy_net: ThreadSafeInferenceWrapper[PolicyOrValueNetwork] = self.get_inference_model(ModelNames.POLICY)
+        self.value_net: ThreadSafeInferenceWrapper[PolicyOrValueNetwork] = self.get_inference_model(ModelNames.VALUE)
+
+    # ------ Interaction Process ------
+    exact_forward_dynamics_hidden_state: Tensor
+    predicted_embed_obs_dists: list[Distribution]
+    predicted_embed_obses: list[Tensor]
+    forward_dynamics_hidden_states: list[Tensor]
+    step_data: StepData
+
+    def _common_step(self, observation: Tensor, initial_step: bool = False) -> Tensor:
+        """Common step procedure for agent.
+
+        If `initial_step` is False, some procedures are skipped.
+        """
+        embed_obs = self.image_encoder(observation)
+
+        if not initial_step:
+            # 報酬計算は初期ステップではできないためスキップ。
+            rewards = []
+            for dist in self.predicted_embed_obs_dists:
+                rewards.append(self.reward_computer.compute(dist, embed_obs))
+
+            self.logger.log("agent/reward", rewards[0])
+            for i, r in enumerate(rewards, start=1):
+                self.logger.log(f"agent/reward_{i}step", r)
+
+            # ステップの冒頭でデータコレクトすることで前ステップのデータを収集する。
+            self.step_data[DataKeys.REWARD] = rewards[0]
+            self.data_collectors.collect(self.step_data)
+
+        self.step_data[DataKeys.OBSERVATION] = observation  # o_t
+        self.step_data[DataKeys.EMBED_OBSERVATION] = embed_obs  # z_t
+
+        embed_obs_list = [embed_obs, *self.predicted_embed_obses]
+        hidden_list = [self.exact_forward_dynamics_hidden_state, *self.forward_dynamics_hidden_states]
+
+        # buffer lists.
+        pred_embed_obs_dist_list = []
+        pred_embed_obs_list = []
+        next_hidden_list = []
+        action_list = []
+        action_log_prob_list = []
+        value_list = []
+
+        for i in range(min(self.max_imagination_steps, len(embed_obs_list))):
+            action_dist: Distribution = self.policy_net(embed_obs_list[i], hidden_list[i])
+            value_dist: Distribution = self.value_net(embed_obs_list[i], hidden_list[i])
+            action, value = action_dist.sample(), value_dist.sample()
+            action_log_prob = action_dist.log_prob(action)
+            action_list.append(action)
+            action_log_prob_list.append(action_log_prob)
+            value_list.append(value)
+
+            pred_obs_dist, _, _, hidden = self.forward_dynamics(embed_obs_list[i], hidden_list[i], action)
+            pred_obs = pred_obs_dist.sample()
+            pred_embed_obs_dist_list.append(pred_obs_dist)
+            pred_embed_obs_list.append(pred_obs)
+            next_hidden_list.append(hidden)
+
+        self.step_data[DataKeys.ACTION] = action_list[0]  # a_t
+        self.step_data[DataKeys.ACTION_LOG_PROBABILITY] = action_log_prob_list[0]  # log \pi(a_t | o_t, h_t)
+        self.step_data[DataKeys.VALUE] = value_list[0]  # v_t
+        self.step_data[DataKeys.HIDDEN] = self.exact_forward_dynamics_hidden_state  # h_t
+        self.logger.log("agent/value", value_list[0])
+
+        self.predicted_embed_obs_dists = pred_embed_obs_dist_list
+        self.predicted_embed_obses = pred_embed_obs_list
+        self.forward_dynamics_hidden_states = next_hidden_list
+        self.exact_forward_dynamics_hidden_state = next_hidden_list[0]
+
+        self.logger.update()
+
+        return action_list[0]
+
+    def setup(self, observation: Tensor) -> Tensor:
+        super().setup(observation)
+        self.step_data = StepData()
+        self.predicted_embed_obs_dists = []
+        self.predicted_embed_obses = []
+        self.forward_dynamics_hidden_states = []
+
+        return self._common_step(observation, initial_step=True)
+
+    def step(self, observation: Tensor) -> Tensor:
+        return self._common_step(observation, initial_step=False)
+
+    @override
+    def save_state(self, path: Path) -> None:
+        path.mkdir()
+        torch.save(self.exact_forward_dynamics_hidden_state, path / "exact_forward_dynamics_hidden_state.pt")
+
+    @override
+    def load_state(self, path: Path) -> None:
+        self.exact_forward_dynamics_hidden_state = torch.load(
+            path / "exact_forward_dynamics_hidden_state.pt", map_location="cpu"
+        )

--- a/configs/experiment/dreamer_multi_step_imagination.yaml
+++ b/configs/experiment/dreamer_multi_step_imagination.yaml
@@ -1,0 +1,27 @@
+# @package _global_
+
+defaults:
+  - override /interaction: vrchat_with_curiosity_image_ppo_agent
+  - override /interaction/agent: curiosity_image_multi_step_imagination
+  - override /models: dreamer
+  - override /data_collectors: image_dynamics_dreaming
+  - override /trainers: image_vae_forward_dynamics_dreaming
+
+interaction:
+  action_wrappers:
+    - _target_: ami.interactions.io_wrappers.function_wrapper.FunctionIOWrapper
+      wrap_function:
+        _target_: torch.argmax
+        _partial_: true
+        dim: -1
+
+trainers:
+  image_vae:
+    partial_dataloader:
+      batch_size: 128
+  forward_dynamics:
+    partial_dataloader:
+      batch_size: ${python.eval:128+1}
+    minimum_new_data_count: ${.partial_dataloader.batch_size}
+
+task_name: dreamer_multi_step_imagination

--- a/configs/interaction/agent/curiosity_image_multi_step_imagination.yaml
+++ b/configs/interaction/agent/curiosity_image_multi_step_imagination.yaml
@@ -12,4 +12,4 @@ logger:
   log_dir: ${paths.tensorboard_dir}/agent
   log_every_n_seconds: 0
 
-max_imagination_steps: 10
+max_imagination_steps: 5

--- a/configs/interaction/agent/curiosity_image_multi_step_imagination.yaml
+++ b/configs/interaction/agent/curiosity_image_multi_step_imagination.yaml
@@ -13,4 +13,9 @@ logger:
   log_dir: ${paths.tensorboard_dir}/agent
   log_every_n_seconds: 0
 
-max_imagination_steps: 10
+max_imagination_steps: 50
+
+reward_average_method:
+  _target_: ami.interactions.agents.multi_step_imagination_curiosity_agent.average_exponentially
+  _partial_: true
+  decay: ${python.eval:"1 - 1 / ${..max_imagination_steps}"}

--- a/configs/interaction/agent/curiosity_image_multi_step_imagination.yaml
+++ b/configs/interaction/agent/curiosity_image_multi_step_imagination.yaml
@@ -6,6 +6,7 @@ initial_hidden:
     - ${models.forward_dynamics.model.core_model.depth}
     - ${models.forward_dynamics.model.core_model.dim}
   dtype: ${torch.dtype:float}
+  device: ${devices.0}
 
 logger:
   _target_: ami.tensorboard_loggers.TimeIntervalLogger

--- a/configs/interaction/agent/curiosity_image_multi_step_imagination.yaml
+++ b/configs/interaction/agent/curiosity_image_multi_step_imagination.yaml
@@ -13,4 +13,4 @@ logger:
   log_dir: ${paths.tensorboard_dir}/agent
   log_every_n_seconds: 0
 
-max_imagination_steps: 5
+max_imagination_steps: 10

--- a/configs/interaction/agent/curiosity_image_multi_step_imagination.yaml
+++ b/configs/interaction/agent/curiosity_image_multi_step_imagination.yaml
@@ -1,0 +1,15 @@
+_target_: ami.interactions.agents.multi_step_imagination_curiosity_agent.MultiStepImaginationCuriosityImageAgent
+
+initial_hidden:
+  _target_: torch.zeros
+  _args_:
+    - ${models.forward_dynamics.model.core_model.depth}
+    - ${models.forward_dynamics.model.core_model.dim}
+  dtype: ${torch.dtype:float}
+
+logger:
+  _target_: ami.tensorboard_loggers.TimeIntervalLogger
+  log_dir: ${paths.tensorboard_dir}/agent
+  log_every_n_seconds: 0
+
+max_imagination_steps: 64

--- a/configs/interaction/agent/curiosity_image_multi_step_imagination.yaml
+++ b/configs/interaction/agent/curiosity_image_multi_step_imagination.yaml
@@ -12,4 +12,4 @@ logger:
   log_dir: ${paths.tensorboard_dir}/agent
   log_every_n_seconds: 0
 
-max_imagination_steps: 64
+max_imagination_steps: 10

--- a/configs/trainers/dreaming_policy_value/default.yaml
+++ b/configs/trainers/dreaming_policy_value/default.yaml
@@ -26,6 +26,7 @@ logger:
 
 device: ${devices.0}
 max_epochs: 1
+entropy_coef: 0.001
 imagination_trajectory_length: 25
 imagination_temperature: 1.0
 minimum_dataset_size: ${.partial_dataloader.batch_size}

--- a/tests/interactions/agents/test_multi_step_imagination_curiosity_agent.py
+++ b/tests/interactions/agents/test_multi_step_imagination_curiosity_agent.py
@@ -110,15 +110,12 @@ class TestMultiStepImaginationCuriosityImageAgent:
         assert agent.step_data[DataKeys.HIDDEN].shape == (DEPTH, SCONV_DIM)
         assert agent.step_data[DataKeys.REWARD].shape == ()
 
-        assert len(agent.predicted_embed_obs_dists) == 3
-        for dist in agent.predicted_embed_obs_dists:
-            assert isinstance(dist, Distribution)
+        assert isinstance(agent.predicted_embed_obs_dists, Distribution)
+        assert len(agent.predicted_embed_obs_dists.sample()) == 3
         assert len(agent.predicted_embed_obses) == 3
-        for tensor in agent.predicted_embed_obses:
-            assert isinstance(tensor, torch.Tensor)
+        assert isinstance(agent.predicted_embed_obses, torch.Tensor)
         assert len(agent.forward_dynamics_hidden_states) == 3
-        for tensor in agent.forward_dynamics_hidden_states:
-            assert isinstance(tensor, torch.Tensor)
+        assert isinstance(agent.forward_dynamics_hidden_states, torch.Tensor)
 
     def test_save_and_load_state(self, agent: MultiStepImaginationCuriosityImageAgent, tmp_path):
         agent_path = tmp_path / "agent"

--- a/tests/interactions/agents/test_multi_step_imagination_curiosity_agent.py
+++ b/tests/interactions/agents/test_multi_step_imagination_curiosity_agent.py
@@ -1,0 +1,133 @@
+import pytest
+import torch
+import torch.nn as nn
+from torch.distributions import Distribution
+
+from ami.data.buffers.buffer_names import BufferNames
+from ami.data.buffers.random_data_buffer import RandomDataBuffer
+from ami.data.utils import DataCollectorsDict
+from ami.interactions.agents.multi_step_imagination_curiosity_agent import (
+    DataKeys,
+    ForwardDynamcisWithActionReward,
+    ModelNames,
+    MultiStepImaginationCuriosityImageAgent,
+    PolicyOrValueNetwork,
+)
+from ami.models.components.fully_connected_normal import FullyConnectedNormal
+from ami.models.components.sconv import SConv
+from ami.models.components.small_conv_net import SmallConvNet
+from ami.models.policy_value_common_net import SelectObservation
+from ami.models.utils import InferenceWrappersDict, ModelWrapper, ModelWrappersDict
+from ami.tensorboard_loggers import TimeIntervalLogger
+
+CHANNELS, WIDTH, HEIGHT = (3, 128, 128)
+EMBED_OBS_DIM = 64
+ACTION_DIM = 8
+SCONV_DIM = 64
+DEPTH = 2
+
+
+class TestMultiStepImaginationCuriosityImageAgent:
+    @pytest.fixture
+    def inference_models(self, device) -> InferenceWrappersDict:
+        image_encoder = SmallConvNet(WIDTH, HEIGHT, CHANNELS, EMBED_OBS_DIM)
+        forward_dynamics = ForwardDynamcisWithActionReward(
+            nn.Identity(),
+            nn.Identity(),
+            nn.Linear(EMBED_OBS_DIM + ACTION_DIM, SCONV_DIM),
+            SConv(DEPTH, SCONV_DIM, SCONV_DIM, 0.1),
+            FullyConnectedNormal(SCONV_DIM, EMBED_OBS_DIM),
+            FullyConnectedNormal(SCONV_DIM, ACTION_DIM),
+            FullyConnectedNormal(SCONV_DIM, 1, squeeze_feature_dim=True),
+        )
+
+        policy_net = PolicyOrValueNetwork(
+            nn.Identity(),
+            nn.Identity(),
+            SelectObservation(),
+            nn.Linear(EMBED_OBS_DIM, EMBED_OBS_DIM),
+            FullyConnectedNormal(EMBED_OBS_DIM, ACTION_DIM),
+        )
+
+        value_net = PolicyOrValueNetwork(
+            nn.Identity(),
+            nn.Identity(),
+            SelectObservation(),
+            nn.Linear(EMBED_OBS_DIM, EMBED_OBS_DIM),
+            FullyConnectedNormal(EMBED_OBS_DIM, 1, squeeze_feature_dim=True),
+        )
+
+        mwd = ModelWrappersDict(
+            {
+                ModelNames.IMAGE_ENCODER: ModelWrapper(image_encoder, device, True),
+                ModelNames.FORWARD_DYNAMICS: ModelWrapper(forward_dynamics, device, True),
+                ModelNames.POLICY: ModelWrapper(policy_net, device, True),
+                ModelNames.VALUE: ModelWrapper(value_net, device, True),
+            }
+        )
+        mwd.send_to_default_device()
+
+        return mwd.inference_wrappers_dict
+
+    @pytest.fixture
+    def data_collectors(self) -> DataCollectorsDict:
+        empty_buffer = RandomDataBuffer(10, [DataKeys.OBSERVATION])
+        return DataCollectorsDict.from_data_buffers(
+            **{
+                BufferNames.IMAGE: empty_buffer,
+                BufferNames.PPO_TRAJECTORY: empty_buffer,
+            }
+        )
+
+    @pytest.fixture
+    def logger(self, tmp_path):
+        return TimeIntervalLogger(f"{tmp_path}/tensorboard", 0)
+
+    @pytest.fixture
+    def agent(self, inference_models, data_collectors, logger) -> MultiStepImaginationCuriosityImageAgent:
+        curiosity_agent = MultiStepImaginationCuriosityImageAgent(
+            torch.zeros(DEPTH, SCONV_DIM), logger, max_imagination_steps=3
+        )
+        curiosity_agent.attach_data_collectors(data_collectors)
+        curiosity_agent.attach_inference_models(inference_models)
+        return curiosity_agent
+
+    def test_setup_step_teardown(self, agent: MultiStepImaginationCuriosityImageAgent):
+        observation = torch.randn(CHANNELS, HEIGHT, WIDTH)
+        action = agent.setup(observation)
+
+        assert action.shape == (ACTION_DIM,)
+
+        for _ in range(10):
+            action = agent.step(observation)
+            assert action.shape == (ACTION_DIM,)
+
+        assert agent.step_data[DataKeys.OBSERVATION].shape == observation.shape
+        assert agent.step_data[DataKeys.EMBED_OBSERVATION].shape == (EMBED_OBS_DIM,)
+        assert agent.step_data[DataKeys.ACTION].shape == (ACTION_DIM,)
+        assert agent.step_data[DataKeys.ACTION_LOG_PROBABILITY].shape == (ACTION_DIM,)
+        assert agent.step_data[DataKeys.VALUE].shape == ()
+        assert agent.step_data[DataKeys.HIDDEN].shape == (DEPTH, SCONV_DIM)
+        assert agent.step_data[DataKeys.REWARD].shape == ()
+
+        assert len(agent.predicted_embed_obs_dists) == 3
+        for dist in agent.predicted_embed_obs_dists:
+            assert isinstance(dist, Distribution)
+        assert len(agent.predicted_embed_obses) == 3
+        for tensor in agent.predicted_embed_obses:
+            assert isinstance(tensor, torch.Tensor)
+        assert len(agent.forward_dynamics_hidden_states) == 3
+        for tensor in agent.forward_dynamics_hidden_states:
+            assert isinstance(tensor, torch.Tensor)
+
+    def test_save_and_load_state(self, agent: MultiStepImaginationCuriosityImageAgent, tmp_path):
+        agent_path = tmp_path / "agent"
+        agent.save_state(agent_path)
+        assert (agent_path / "exact_forward_dynamics_hidden_state.pt").exists()
+
+        hidden = agent.exact_forward_dynamics_hidden_state.clone()
+        agent.exact_forward_dynamics_hidden_state = torch.randn_like(hidden)
+        assert not torch.equal(agent.exact_forward_dynamics_hidden_state, hidden)
+
+        agent.load_state(agent_path)
+        assert torch.equal(agent.exact_forward_dynamics_hidden_state, hidden)

--- a/tests/interactions/agents/test_multi_step_imagination_curiosity_agent.py
+++ b/tests/interactions/agents/test_multi_step_imagination_curiosity_agent.py
@@ -117,12 +117,12 @@ class TestMultiStepImaginationCuriosityImageAgent:
         assert agent.step_data[DataKeys.HIDDEN].shape == (DEPTH, SIOCONV_DIM)
         assert agent.step_data[DataKeys.REWARD].shape == ()
 
-        assert isinstance(agent.predicted_embed_obs_dists, Distribution)
-        assert len(agent.predicted_embed_obs_dists.sample()) == 3
-        assert len(agent.predicted_embed_obses) == 3
-        assert isinstance(agent.predicted_embed_obses, torch.Tensor)
-        assert len(agent.forward_dynamics_hidden_states) == 3
-        assert isinstance(agent.forward_dynamics_hidden_states, torch.Tensor)
+        assert isinstance(agent.predicted_embed_obs_dist_imaginations, Distribution)
+        assert len(agent.predicted_embed_obs_dist_imaginations.sample()) == 3
+        assert len(agent.predicted_embed_obs_imaginations) == 3
+        assert isinstance(agent.predicted_embed_obs_imaginations, torch.Tensor)
+        assert len(agent.forward_dynamics_hidden_state_imaginations) == 3
+        assert isinstance(agent.forward_dynamics_hidden_state_imaginations, torch.Tensor)
 
     def test_save_and_load_state(self, agent: MultiStepImaginationCuriosityImageAgent, tmp_path):
         agent_path = tmp_path / "agent"

--- a/tests/test_configs.py
+++ b/tests/test_configs.py
@@ -1,6 +1,7 @@
 """ここではconfigファイル上からオブジェクトを正常にインスタンス化可能かテストします。"""
 import hydra
 import pytest
+import torch
 from hydra.utils import instantiate
 from pytest_mock import MockerFixture
 
@@ -33,7 +34,7 @@ def test_instantiate(overrides: list[str], mocker: MockerFixture, tmp_path):
     mocker.patch("cv2.VideoCapture")
     mocker.patch("pythonosc.udp_client.SimpleUDPClient")
     with hydra.initialize_config_dir(str(CONFIG_DIR)):
-        cfg = hydra.compose(LAUNCH_CONFIG, overrides=overrides, return_hydra_config=True)
+        cfg = hydra.compose(LAUNCH_CONFIG, overrides=overrides + ["devices=cpu"], return_hydra_config=True)
         cfg.paths.output_dir = tmp_path
 
         interaction = instantiate(cfg.interaction)


### PR DESCRIPTION
## 概要

1 - Nステップの予測軌道から予測誤差を計算し、その平均を報酬とするAgentを作成しました。

1ステップ前の観測から予測したものの誤差から、Nステップ前から空想してきて予測したもの誤差を算出します。
空想軌道が長くなればなるほど予測は外れやすくなると思ったので、とりあえず指数関数的に減衰させて総和を取り、その係数の総和で割ることで平均を計算しました。

デフォルトでは最大 5秒前からの予想における誤差を加味します。減衰率は `1 - 1 / step数`としています。

時間を分解して考えた時のメモです。

![IMG_1848](https://github.com/user-attachments/assets/8cb15542-7755-4a4a-a11c-f0e4eeaefe95)


## 変更内容

<!-- ビューの変更がある場合はスクショによる比較などがあるとわかりやすい -->

## 影響範囲

<!-- この関数を変更したのでこの機能にも影響がある、など -->

## Submit前の確認項目

<!-- PRをSubmitする前に確認する項目 -->

- [x] タイトルは一目でわかるようにし、説明文は PR を簡潔に説明するようにしましたか?
- [x] あなたの PR が、異なる変更を束ねたものではなく、ひとつのことだけを行うものであることを確認しましたか?
- [x] この PR で導入されたすべての変更点をリストアップしましたか?
- [x] PR を`make run`コマンドでローカルでテストしましたか?

## 補足

<!-- レビューをする際に見てほしい点、ローカル環境で試す際の注意点、など -->
