### PR TITLE
SideChannelでUnity側から位置情報送信

### DIFF
--- a/ami/interactions/environments/unity_environment.py
+++ b/ami/interactions/environments/unity_environment.py
@@ -76,18 +76,12 @@ class UnityEnvironment(BaseEnvironment[Tensor, Tensor]):
         super().__init__()
 
         self.engine_configuration_channel = EngineConfigurationChannel()
+        side_channels = [self.engine_configuration_channel]
         if log_file_path is not None:
             transform_log_channel = TransformLogChannel(UUID("621f0a70-4f87-11ea-a6bf-784f4387d1f7"), log_file_path)
+            side_channels.append(transform_log_channel)
         self._env = UnityToGymWrapper(
-            RawUnityEnv(
-                file_path,
-                worker_id,
-                base_port,
-                seed=seed,
-                side_channels=[self.engine_configuration_channel, transform_log_channel]
-                if log_file_path is not None
-                else [self.engine_configuration_channel],
-            ),
+            RawUnityEnv(file_path, worker_id, base_port, seed=seed, side_channels=side_channels),
             allow_multiple_obs=False,
         )
         self.engine_configuration_channel.set_configuration_parameters(

--- a/ami/interactions/environments/unity_environment.py
+++ b/ami/interactions/environments/unity_environment.py
@@ -15,7 +15,7 @@ from typing_extensions import override
 from .base_environment import BaseEnvironment
 
 
-class TransformLogChannel(SideChannel): # type: ignore
+class TransformLogChannel(SideChannel):  # type: ignore
     def __init__(self, id: UUID, log_file_path: str):
         super().__init__(id)
         self.log_file_path = log_file_path

--- a/ami/interactions/environments/unity_environment.py
+++ b/ami/interactions/environments/unity_environment.py
@@ -1,4 +1,5 @@
 from typing import Any
+from uuid import UUID
 
 import torch
 from mlagents_envs.environment import UnityEnvironment as RawUnityEnv
@@ -6,23 +7,20 @@ from mlagents_envs.envs.unity_gym_env import UnityToGymWrapper
 from mlagents_envs.side_channel.engine_configuration_channel import (
     EngineConfigurationChannel,
 )
+from mlagents_envs.side_channel.side_channel import IncomingMessage, SideChannel
 from numpy.typing import NDArray
 from torch import Tensor
 from typing_extensions import override
 
 from .base_environment import BaseEnvironment
-from mlagents_envs.side_channel.side_channel import (
-    SideChannel,
-    IncomingMessage,
-)
-import uuid
+
 
 class TransformLogChannel(SideChannel):
-    def __init__(self, id, log_file_path):
+    def __init__(self, id: UUID, log_file_path: str):
         super().__init__(id)
         self.log_file_path = log_file_path
 
-    def on_message_received(self, msg: IncomingMessage):
+    def on_message_received(self, msg: IncomingMessage) -> None:
         with open(self.log_file_path, mode="a") as f:
             value_list = msg.read_float32_list()
             frame_count = value_list[0]
@@ -32,8 +30,11 @@ class TransformLogChannel(SideChannel):
             euler_x = value_list[4]
             euler_y = value_list[5]
             euler_z = value_list[6]
-            format_string = f"{frame_count}, {position_x}, {position_y}, {position_z}, {euler_x}, {euler_y}, {euler_z}\n"
+            format_string = (
+                f"{frame_count}, {position_x}, {position_y}, {position_z}, {euler_x}, {euler_y}, {euler_z}\n"
+            )
             f.write(format_string)
+
 
 class UnityEnvironment(BaseEnvironment[Tensor, Tensor]):
     """A class for connecting to and interacting with a Unity ML Agents
@@ -48,7 +49,7 @@ class UnityEnvironment(BaseEnvironment[Tensor, Tensor]):
     def __init__(
         self,
         file_path: str,
-        log_file_path: str,
+        log_file_path: str | None = None,
         worker_id: int = 0,
         base_port: int | None = None,
         seed: int = 0,
@@ -73,14 +74,17 @@ class UnityEnvironment(BaseEnvironment[Tensor, Tensor]):
         super().__init__()
 
         self.engine_configuration_channel = EngineConfigurationChannel()
-        transform_log_channel = TransformLogChannel(uuid.UUID("621f0a70-4f87-11ea-a6bf-784f4387d1f7"), log_file_path)
+        if log_file_path is not None:
+            transform_log_channel = TransformLogChannel(UUID("621f0a70-4f87-11ea-a6bf-784f4387d1f7"), log_file_path)
         self._env = UnityToGymWrapper(
             RawUnityEnv(
                 file_path,
                 worker_id,
                 base_port,
                 seed=seed,
-                side_channels=[self.engine_configuration_channel, transform_log_channel],
+                side_channels=[self.engine_configuration_channel, transform_log_channel]
+                if log_file_path is not None
+                else [self.engine_configuration_channel],
             ),
             allow_multiple_obs=False,
         )

--- a/ami/interactions/environments/unity_environment.py
+++ b/ami/interactions/environments/unity_environment.py
@@ -18,20 +18,22 @@ from mlagents_envs.side_channel.side_channel import (
 import uuid
 
 class TransformLogChannel(SideChannel):
-    def __init__(self, id):
+    def __init__(self, id, log_file_path):
         super().__init__(id)
+        self.log_file_path = log_file_path
 
     def on_message_received(self, msg: IncomingMessage):
-        value_list = msg.read_float32_list()
-        frame_count = value_list[0]
-        position_x = value_list[1]
-        position_y = value_list[2]
-        position_z = value_list[3]
-        euler_x = value_list[4]
-        euler_y = value_list[5]
-        euler_z = value_list[6]
-        format_string = f"{frame_count}, {position_x}, {position_y}, {position_z}, {euler_x}, {euler_y}, {euler_z}"
-        print(format_string)
+        with open(self.log_file_path, mode="a") as f:
+            value_list = msg.read_float32_list()
+            frame_count = value_list[0]
+            position_x = value_list[1]
+            position_y = value_list[2]
+            position_z = value_list[3]
+            euler_x = value_list[4]
+            euler_y = value_list[5]
+            euler_z = value_list[6]
+            format_string = f"{frame_count}, {position_x}, {position_y}, {position_z}, {euler_x}, {euler_y}, {euler_z}\n"
+            f.write(format_string)
 
 class UnityEnvironment(BaseEnvironment[Tensor, Tensor]):
     """A class for connecting to and interacting with a Unity ML Agents
@@ -46,6 +48,7 @@ class UnityEnvironment(BaseEnvironment[Tensor, Tensor]):
     def __init__(
         self,
         file_path: str,
+        log_file_path: str,
         worker_id: int = 0,
         base_port: int | None = None,
         seed: int = 0,
@@ -70,7 +73,7 @@ class UnityEnvironment(BaseEnvironment[Tensor, Tensor]):
         super().__init__()
 
         self.engine_configuration_channel = EngineConfigurationChannel()
-        transform_log_channel = TransformLogChannel(uuid.UUID("621f0a70-4f87-11ea-a6bf-784f4387d1f7"))
+        transform_log_channel = TransformLogChannel(uuid.UUID("621f0a70-4f87-11ea-a6bf-784f4387d1f7"), log_file_path)
         self._env = UnityToGymWrapper(
             RawUnityEnv(
                 file_path,

--- a/ami/interactions/environments/unity_environment.py
+++ b/ami/interactions/environments/unity_environment.py
@@ -15,7 +15,7 @@ from typing_extensions import override
 from .base_environment import BaseEnvironment
 
 
-class TransformLogChannel(SideChannel):
+class TransformLogChannel(SideChannel): # type: ignore
     def __init__(self, id: UUID, log_file_path: str):
         super().__init__(id)
         self.log_file_path = log_file_path

--- a/ami/interactions/environments/unity_environment.py
+++ b/ami/interactions/environments/unity_environment.py
@@ -19,6 +19,8 @@ class TransformLogChannel(SideChannel):  # type: ignore
     def __init__(self, id: UUID, log_file_path: str):
         super().__init__(id)
         self.log_file_path = log_file_path
+        with open(self.log_file_path, mode="w") as f:
+            f.write("frame_count, position_x, position_y, position_z, eular_x, eular_y, eular_z\n")
 
     def on_message_received(self, msg: IncomingMessage) -> None:
         with open(self.log_file_path, mode="a") as f:

--- a/configs/experiment/unity_sioconv.yaml
+++ b/configs/experiment/unity_sioconv.yaml
@@ -7,7 +7,7 @@ defaults:
 interaction:
   environment:
     file_path: ${unity_env_path}
-    log_file_path: ${paths.output_dir}/unity.csv
+    log_file_path: ${paths.output_dir}/unity_information_logs.csv
     worker_id: ${unity_worker_id}
 
 unity_env_path: ??? # Please specify the arg `unity_env_path='<path/to/executable>'

--- a/configs/experiment/unity_sioconv.yaml
+++ b/configs/experiment/unity_sioconv.yaml
@@ -7,6 +7,7 @@ defaults:
 interaction:
   environment:
     file_path: ${unity_env_path}
+    log_file_path: ${paths.output_dir}/unity.csv
     worker_id: ${unity_worker_id}
 
 unity_env_path: ??? # Please specify the arg `unity_env_path='<path/to/executable>'

--- a/configs/interaction/environment/unity.yaml
+++ b/configs/interaction/environment/unity.yaml
@@ -1,7 +1,7 @@
 _target_: ami.interactions.environments.unity_environment.UnityEnvironment
 
 file_path: ???
-log_file_path: ???
+log_file_path: null
 worker_id: 0
 
 time_scale: ${time_scale}

--- a/configs/interaction/environment/unity.yaml
+++ b/configs/interaction/environment/unity.yaml
@@ -1,6 +1,7 @@
 _target_: ami.interactions.environments.unity_environment.UnityEnvironment
 
 file_path: ???
+log_file_path: ???
 worker_id: 0
 
 time_scale: ${time_scale}

--- a/tests/interactions/environments/test_unity_environment.py
+++ b/tests/interactions/environments/test_unity_environment.py
@@ -16,7 +16,7 @@ class TestUnityEnvironment:
 
     @pytest.fixture
     def unity_env(self, mock_unity_env):
-        return UnityEnvironment("dummy_path", "dummy_path", worker_id=0, base_port=5005, seed=42)
+        return UnityEnvironment("dummy_path", worker_id=0, base_port=5005, seed=42)
 
     def test_setup(self, unity_env, mock_unity_env):
         mock_unity_env.reset.return_value = np.zeros(10)

--- a/tests/interactions/environments/test_unity_environment.py
+++ b/tests/interactions/environments/test_unity_environment.py
@@ -16,7 +16,7 @@ class TestUnityEnvironment:
 
     @pytest.fixture
     def unity_env(self, mock_unity_env):
-        return UnityEnvironment("dummy_path", worker_id=0, base_port=5005, seed=42)
+        return UnityEnvironment("dummy_path", "dummy_path", worker_id=0, base_port=5005, seed=42)
 
     def test_setup(self, unity_env, mock_unity_env):
         mock_unity_env.reset.return_value = np.zeros(10)


### PR DESCRIPTION
## 概要

<!-- 変更の目的 もしくは 関連する Issue 番号 -->
Unity側から送信したフレーム数、位置、オイラー角をcsvに記録
https://github.com/MLShukai/AMIUnityEnvironment/pull/4 が必要

mypyで`SideChannel`の型エラーが出ているので`# type: ignore`をつけてる
```
ami/interactions/environments/unity_environment.py:18: error: Class cannot subclass "SideChannel" (has type "Any")  [misc]
```

## 変更内容

<!-- ビューの変更がある場合はスクショによる比較などがあるとわかりやすい -->

## 影響範囲

<!-- この関数を変更したのでこの機能にも影響がある、など -->

## Submit前の確認項目

<!-- PRをSubmitする前に確認する項目 -->

- [x] タイトルは一目でわかるようにし、説明文は PR を簡潔に説明するようにしましたか?
- [x] あなたの PR が、異なる変更を束ねたものではなく、ひとつのことだけを行うものであることを確認しましたか?
- [x] この PR で導入されたすべての変更点をリストアップしましたか?
- [ ] PR を`make run`コマンドでローカルでテストしましたか?

## 補足

<!-- レビューをする際に見てほしい点、ローカル環境で試す際の注意点、など -->
