### PR TITLE
Dreamerの学習にLR Schedulerを追加し、初期の学習率を0に設定

### DIFF
--- a/ami/trainers/dreaming_policy_value_trainer.py
+++ b/ami/trainers/dreaming_policy_value_trainer.py
@@ -23,6 +23,10 @@ from ami.tensorboard_loggers import StepIntervalLogger
 from .base_trainer import BaseTrainer
 
 
+def lambda_no_modify_lr(epoch: int) -> float:
+    return 1.0
+
+
 class ImaginationTrajectory(TypedDict):
     """TypedDict which contains the outputs of imagination."""
 
@@ -51,6 +55,8 @@ class DreamingPolicyValueTrainer(BaseTrainer):
         partial_value_optimizer: partial[Optimizer],
         device: torch.device,
         logger: StepIntervalLogger,
+        partial_policy_lr_scheduler: partial[LRScheduler] | None = None,
+        partial_value_lr_scheduler: partial[LRScheduler] | None = None,
         max_epochs: int = 1,
         imagination_trajectory_length: int = 1,
         discount_factor: float = 0.99,  # gamma for rl
@@ -68,6 +74,8 @@ class DreamingPolicyValueTrainer(BaseTrainer):
             partial_value_optimizer: A partially instantiated optimizer for value lacking provided parameters.
             device: The accelerator device (e.g., CPU, GPU) utilized for training the model.
             logger: A StepIntervalLogger object for logging training progress.
+            partial_policy_lr_scheduler: A partially instantiated lr scheduler for the policy network optimizer.
+            partial_value_lr_scheduler: A partially instantiated lr scheduler for the value network optimizer.
             max_epochs: Maximum number of epochs for training.
             imagination_trajectory_length: The length of dreaming steps.
             discount_factor: Discount factor (gamma) for reinforcement learning.
@@ -84,6 +92,16 @@ class DreamingPolicyValueTrainer(BaseTrainer):
         self.device = device
         self.logger = logger
         self.max_epochs = max_epochs
+        self.partial_policy_lr_scheduler = (
+            partial_policy_lr_scheduler
+            if partial_policy_lr_scheduler is not None
+            else partial(LambdaLR, lr_lambda=lambda_no_modify_lr)
+        )
+        self.partial_value_lr_scheduler = (
+            partial_value_lr_scheduler
+            if partial_value_lr_scheduler is not None
+            else partial(LambdaLR, lr_lambda=lambda_no_modify_lr)
+        )
         self.imagination_trajectory_length = imagination_trajectory_length
         self.discount_factor = discount_factor
         self.eligibility_trace_decay = eligibility_trace_decay
@@ -107,8 +125,13 @@ class DreamingPolicyValueTrainer(BaseTrainer):
         self.policy_net: ModelWrapper[PolicyOrValueNetwork] = self.get_training_model(ModelNames.POLICY)
         self.value_net: ModelWrapper[PolicyOrValueNetwork] = self.get_training_model(ModelNames.VALUE)
 
-        self.policy_optimizer_state = self.partial_policy_optimizer(self.policy_net.parameters()).state_dict()
-        self.value_optimizer_state = self.partial_value_optimizer(self.value_net.parameters()).state_dict()
+        policy_optim = self.partial_policy_optimizer(self.policy_net.parameters())
+        value_optim = self.partial_value_optimizer(self.value_net.parameters())
+        self.policy_optimizer_state = policy_optim.state_dict()
+        self.value_optimizer_state = value_optim.state_dict()
+
+        self.policy_lr_scheduler_state = self.partial_policy_lr_scheduler(optimizer=policy_optim).state_dict()  # type: ignore
+        self.value_lr_scheduler_state = self.partial_value_lr_scheduler(value_optim).state_dict()  # type: ignore
 
     @override
     def is_trainable(self) -> bool:
@@ -133,6 +156,12 @@ class DreamingPolicyValueTrainer(BaseTrainer):
         policy_optimizer.load_state_dict(self.policy_optimizer_state)
         value_optimizer = self.partial_value_optimizer(self.value_net.parameters())
         value_optimizer.load_state_dict(self.value_optimizer_state)
+
+        # Setup schedulers
+        policy_lr_scheduler = self.partial_policy_lr_scheduler(policy_optimizer)  # type: ignore
+        policy_lr_scheduler.load_state_dict(self.policy_lr_scheduler_state)
+        value_lr_scheduler = self.partial_value_lr_scheduler(value_optimizer)  # type: ignore
+        value_lr_scheduler.load_state_dict(self.value_lr_scheduler_state)
 
         # Setup dataset
         dataset = self.initial_states_data_user.get_dataset()
@@ -187,8 +216,14 @@ class DreamingPolicyValueTrainer(BaseTrainer):
                 self.logger.log(prefix + "value_loss", value_loss)
                 self.logger.update()
 
+            # Updating LR Schedulers
+            policy_lr_scheduler.step()
+            value_lr_scheduler.step()
+
         self.policy_optimizer_state = policy_optimizer.state_dict()
         self.value_optimizer_state = value_optimizer.state_dict()
+        self.policy_lr_scheduler_state = policy_lr_scheduler.state_dict()
+        self.value_lr_scheduler_state = value_lr_scheduler.state_dict()
 
     def imagine_trajectory(self, initial_state: tuple[Tensor, Tensor]) -> ImaginationTrajectory:
         """Imagines a trajectory of states, actions, and rewards using the
@@ -268,12 +303,16 @@ class DreamingPolicyValueTrainer(BaseTrainer):
         path.mkdir()
         torch.save(self.policy_optimizer_state, path / "policy_optimizer.pt")
         torch.save(self.value_optimizer_state, path / "value_optimizer.pt")
+        torch.save(self.policy_lr_scheduler_state, path / "policy_lr_scheduler.pt")
+        torch.save(self.value_lr_scheduler_state, path / "value_lr_scheduler.pt")
         torch.save(self.logger.state_dict(), path / "logger.pt")
 
     @override
     def load_state(self, path: Path) -> None:
         self.policy_optimizer_state = torch.load(path / "policy_optimizer.pt")
         self.value_optimizer_state = torch.load(path / "value_optimizer.pt")
+        self.policy_lr_scheduler_state = torch.load(path / "policy_lr_scheduler.pt")
+        self.value_lr_scheduler_state = torch.load(path / "value_lr_scheduler.pt")
         self.logger.load_state_dict(torch.load(path / "logger.pt"))
 
 

--- a/configs/trainers/dreaming_policy_value/default.yaml
+++ b/configs/trainers/dreaming_policy_value/default.yaml
@@ -19,6 +19,20 @@ partial_value_optimizer:
   lr: 1e-4
   betas: [0.9, 0.999]
 
+partial_policy_lr_scheduler:
+  _target_: ami.trainers.dreaming_policy_value_trainer.InitialMultiplicationLRScheduler
+  _partial_: true
+  multiplication_factor: 0.0
+  initial_epochs: ${python.eval:"50 * ${..max_epochs}"} # 大体10分くらい。
+  verbose: true
+
+partial_value_lr_scheduler:
+  _target_: ami.trainers.dreaming_policy_value_trainer.InitialMultiplicationLRScheduler
+  _partial_: true
+  multiplication_factor: 0.0
+  initial_epochs: ${python.eval:"50 * ${..max_epochs}"} # 大体10分くらい。
+  verbose: true
+
 logger:
   _target_: ami.tensorboard_loggers.StepIntervalLogger
   log_dir: ${paths.tensorboard_dir}/forward_dynamics

--- a/tests/trainers/test_dreaming_policy_value_trainer.py
+++ b/tests/trainers/test_dreaming_policy_value_trainer.py
@@ -19,6 +19,7 @@ from ami.trainers.dreaming_policy_value_trainer import (
     BufferNames,
     DreamingPolicyValueTrainer,
     ForwardDynamcisWithActionReward,
+    InitialMultiplicationLRScheduler,
     ModelNames,
     ModelWrapper,
     PolicyOrValueNetwork,
@@ -177,3 +178,22 @@ class TestDreamingPolicyValueTrainer:
         assert trainer.policy_optimizer_state != {}
         assert trainer.value_optimizer_state != {}
         mocked_logger_load_state_dict.assert_called_once_with(logger_state)
+
+
+class TestInitialMultiplicationLRScheduler:
+    def test_lr(self):
+        layer = nn.Linear(3, 1)
+        optim = torch.optim.Adam(layer.parameters(), lr=1.0)
+
+        initial_epochs = 2
+        scheduler = InitialMultiplicationLRScheduler(optim, 0.1, initial_epochs)
+
+        loss = layer(torch.randn(3))
+        loss.backward()
+        optim.step()
+
+        assert scheduler.get_last_lr() == [0.1]
+        scheduler.step()
+        assert scheduler.get_last_lr() == [0.1]
+        scheduler.step()
+        assert scheduler.get_last_lr() == [1.0]


### PR DESCRIPTION
## 概要

Forward DynamicsやObservation Encoderの学習初期は世界モデルが世界を近似できておらず、その状態で PolicyとValueを学習すると局所解に落ちてしまう問題があった。そのため、初期の学習率を0.0に設定するようにしたことで、この問題を解消した。

次の画像はSimple Worldで学習した際のものである。
学習を開始した後は、行動のエントロピーは維持しつつ、Forward Dynamicsの action lossが低下したため、ある程度規則的な、学習による行動が獲得されたと考える。


<img width="629" alt="スクリーンショット 2024-08-11 午後8 24 39" src="https://github.com/user-attachments/assets/8a1348d0-8086-455a-b98d-46dfa8616875">
<img width="629" alt="スクリーンショット 2024-08-11 午後8 25 06" src="https://github.com/user-attachments/assets/d981317f-750a-41cb-8163-4f7fa2759dc2">


## 変更内容

<!-- ビューの変更がある場合はスクショによる比較などがあるとわかりやすい -->

## 影響範囲

<!-- この関数を変更したのでこの機能にも影響がある、など -->

## Submit前の確認項目

<!-- PRをSubmitする前に確認する項目 -->

- [x] タイトルは一目でわかるようにし、説明文は PR を簡潔に説明するようにしましたか?
- [x] あなたの PR が、異なる変更を束ねたものではなく、ひとつのことだけを行うものであることを確認しましたか?
- [x] この PR で導入されたすべての変更点をリストアップしましたか?
- [x] PR を`make run`コマンドでローカルでテストしましたか?

## 補足

<!-- レビューをする際に見てほしい点、ローカル環境で試す際の注意点、など -->
