### PR TITLE
観測をnormalize

### DIFF
--- a/ami/interactions/io_wrappers/function_wrapper.py
+++ b/ami/interactions/io_wrappers/function_wrapper.py
@@ -1,5 +1,7 @@
 from typing import Callable, Generic
 
+import torch
+
 from .base_io_wrapper import BaseIOWrapper, WrappedType, WrappingType
 
 
@@ -11,3 +13,19 @@ class FunctionIOWrapper(BaseIOWrapper[WrappingType, WrappedType], Generic[Wrappi
 
     def wrap(self, input: WrappingType) -> WrappedType:
         return self.wrap_function(input)
+
+
+def normalize_tensor(x: torch.Tensor, eps: float = 1e-6) -> torch.Tensor:
+    """Normalizes the input tensor to have a mean of 0 and standard deviation
+    of 1.
+
+    Args:
+        x (torch.Tensor): Input tensor to be normalized
+        epsilon (float): Small value to prevent division by zero
+
+    Returns:
+        torch.Tensor: Normalized tensor
+    """
+    mean = torch.mean(x)
+    std = torch.std(x)
+    return (x - mean) / (std + eps)

--- a/configs/experiment/dreamer.yaml
+++ b/configs/experiment/dreamer.yaml
@@ -16,6 +16,14 @@ interaction:
         - ${models.forward_dynamics.model.core_model.depth}
         - ${models.forward_dynamics.model.core_model.dim}
       dtype: ${torch.dtype:float}
+
+  observation_wrappers:
+    - _target_: ami.interactions.io_wrappers.function_wrapper.FunctionIOWrapper
+      wrap_function:
+        _target_: ami.interactions.io_wrappers.function_wrapper.normalize_tensor
+        _partial_: True
+        eps: 1e-6
+
   action_wrappers:
     - _target_: ami.interactions.io_wrappers.function_wrapper.FunctionIOWrapper
       wrap_function:

--- a/tests/interactions/io_wrappers/test_function_io_wrapper.py
+++ b/tests/interactions/io_wrappers/test_function_io_wrapper.py
@@ -1,6 +1,11 @@
+import pytest
+import torch
 from pytest_mock import MockerFixture
 
-from ami.interactions.io_wrappers.function_wrapper import FunctionIOWrapper
+from ami.interactions.io_wrappers.function_wrapper import (
+    FunctionIOWrapper,
+    normalize_tensor,
+)
 
 
 class TestFunctionIOWrapper:
@@ -8,3 +13,10 @@ class TestFunctionIOWrapper:
         wrap_function = mocker.Mock(return_value="wrapped")
         wrapper = FunctionIOWrapper(wrap_function)
         assert wrapper.wrap("input") == "wrapped"
+
+
+def test_normalize_tensor():
+    for _ in range(10):
+        out = normalize_tensor(torch.rand(100))
+        assert out.mean() == pytest.approx(0.0, abs=1e-5)
+        assert out.std() == pytest.approx(1.0, abs=1e-5)


### PR DESCRIPTION
## 概要

Japan Streetでの学習において、夜間と昼間で損失が上下する現象が発生していた。夜間は暗くなり、データレンジが小さくなるため損失が小さくなりやすい。その結果 Forward Dynamicsの損失へも影響が出ていた。

観測の平均と分散を1,0に正規化することにより、ある程度解消された。（詳細はDiscordに記述した通り）


## 変更内容

<!-- ビューの変更がある場合はスクショによる比較などがあるとわかりやすい -->

## 影響範囲

<!-- この関数を変更したのでこの機能にも影響がある、など -->

## Submit前の確認項目

<!-- PRをSubmitする前に確認する項目 -->

- [x] タイトルは一目でわかるようにし、説明文は PR を簡潔に説明するようにしましたか?
- [x] あなたの PR が、異なる変更を束ねたものではなく、ひとつのことだけを行うものであることを確認しましたか?
- [x] この PR で導入されたすべての変更点をリストアップしましたか?
- [x] PR を`make run`コマンドでローカルでテストしましたか?

## 補足

<!-- レビューをする際に見てほしい点、ローカル環境で試す際の注意点、など -->
