### PR TITLE
Bool Mask版IJEPAのPredictorのマスク仕様の変更と計算量削減のリファクタリング

### DIFF
--- a/configs/models/bool_mask_i_jepa.yaml
+++ b/configs/models/bool_mask_i_jepa.yaml
@@ -31,7 +31,7 @@ i_jepa_predictor:
   default_device: ${devices.0}
   has_inference: False
   model:
-    _target_: ami.models.bool_mask_i_jepa.BoolMaskIJEPAPredictor
+    _target_: ami.models.bool_mask_i_jepa.BoolTargetIJEPAPredictor
     n_patches:
       - ${python.eval:"${shared.image_height} // ${models.i_jepa_target_encoder.model.patch_size}"}
       - ${python.eval:"${shared.image_width} // ${models.i_jepa_target_encoder.model.patch_size}"}

--- a/tests/models/test_bool_mask_i_jepa.py
+++ b/tests/models/test_bool_mask_i_jepa.py
@@ -3,7 +3,7 @@ import torch
 
 from ami.models.bool_mask_i_jepa import (
     BoolMaskIJEPAEncoder,
-    BoolMaskIJEPAPredictor,
+    BoolTargetIJEPAPredictor,
     ModelWrapper,
     i_jepa_encoder_infer,
 )
@@ -87,7 +87,7 @@ class TestBoolMaskIEPAEncoder:
         assert latent.size(2) == out_dim, "out_dim mismatch"
 
 
-class TestBoolMaskIEPAPredictor:
+class TestBoolTargetIJEPAPredictor:
     # model params
     @pytest.mark.parametrize("image_size", [224])
     @pytest.mark.parametrize("patch_size", [16])
@@ -97,7 +97,7 @@ class TestBoolMaskIEPAPredictor:
     @pytest.mark.parametrize("num_heads", [2, 4])
     # test input params
     @pytest.mark.parametrize("batch_size", [1, 4])
-    def test_bool_mask_vision_transformer_predictor(
+    def test_bool_target_vision_transformer_predictor(
         self,
         image_size: int,
         patch_size: int,
@@ -112,7 +112,7 @@ class TestBoolMaskIEPAPredictor:
         n_patch_horizontal = image_size // patch_size
         n_patches = n_patch_vertical * n_patch_horizontal
         # define predictor made of ViT
-        predictor = BoolMaskIJEPAPredictor(
+        predictor = BoolTargetIJEPAPredictor(
             n_patches=(n_patch_vertical, n_patch_horizontal),
             context_encoder_out_dim=context_encoder_out_dim,
             hidden_dim=hidden_dim,
@@ -121,11 +121,11 @@ class TestBoolMaskIEPAPredictor:
         )
         # define sample inputs
         latents = torch.randn([batch_size, n_patches, context_encoder_out_dim])
-        masks_for_predictor = make_bool_masks_randomly(batch_size, n_patches)
+        predictor_targets = ~make_bool_masks_randomly(batch_size, n_patches)
         # get predictions
         predictions = predictor(
             latents=latents,
-            masks_for_predictor=masks_for_predictor,
+            predictor_targets=predictor_targets,
         )
         # check size of output predictions
         assert predictions.size(0) == batch_size, "batch_size mismatch"

--- a/tests/trainers/components/test_bool_i_jepa_mask_collator.py
+++ b/tests/trainers/components/test_bool_i_jepa_mask_collator.py
@@ -98,7 +98,7 @@ class TestBoolIJEPAMultiBlockMaskCollator:
         # check that encoder masks and predictor targets are not identical
         assert not torch.all(
             collated_encoder_masks == collated_predictor_targets
-        ), "encoder masks and predictor targets are identical"
+        ), "encoder masks and predictor targets must be different"
 
     def test_sample_masks_and_target(self):
         image_size, patch_size = 224, 16

--- a/tests/trainers/components/test_bool_i_jepa_mask_collator.py
+++ b/tests/trainers/components/test_bool_i_jepa_mask_collator.py
@@ -48,7 +48,7 @@ class TestBoolIJEPAMultiBlockMaskCollator:
         batch_size: int,
     ):
         assert image_size % patch_size == 0
-        # define IJEPABoolMaskCollator
+        # define BoolIJEPAMultiBlockMaskCollator
         collator = BoolIJEPAMultiBlockMaskCollator(
             input_size=(image_size, image_size),
             patch_size=(patch_size, patch_size),
@@ -60,8 +60,8 @@ class TestBoolIJEPAMultiBlockMaskCollator:
         # collate batch and create masks
         (
             collated_images,
-            collated_masks_for_context_encoder,
-            collated_masks_for_predictor,
+            collated_encoder_masks,
+            collated_predictor_targets,
         ) = collator(images)
 
         # check image sizes
@@ -76,28 +76,53 @@ class TestBoolIJEPAMultiBlockMaskCollator:
         n_patch = n_patch_vertical * n_patch_horizontal
 
         # check masks for context encoder
-        assert collated_masks_for_context_encoder.dim() == 2
-        assert (
-            collated_masks_for_context_encoder.size(0) == batch_size
-        ), "batch_size mismatch (masks_for_context_encoder)"
-        assert collated_masks_for_context_encoder.size(1) == n_patch, "patch count mismatch (masks_for_context_encoder)"
-        assert collated_masks_for_context_encoder.dtype == torch.bool, "dtype mismatch (masks_for_context_encoder)"
+        assert collated_encoder_masks.dim() == 2
+        assert collated_encoder_masks.size(0) == batch_size, "batch_size mismatch (collated_encoder_masks)"
+        assert collated_encoder_masks.size(1) == n_patch, "patch count mismatch (collated_encoder_masks)"
+        assert collated_encoder_masks.dtype == torch.bool, "dtype mismatch (collated_encoder_masks)"
 
-        # check masks for predictor
-        assert collated_masks_for_predictor.dim() == 2
-        assert collated_masks_for_predictor.size(0) == batch_size, "batch_size mismatch (masks_for_predictor)"
-        assert collated_masks_for_predictor.size(1) == n_patch, "patch count mismatch (masks_for_predictor)"
-        assert collated_masks_for_predictor.dtype == torch.bool, "dtype mismatch (masks_for_predictor)"
+        # check masks for predictor target
+        assert collated_predictor_targets.dim() == 2
+        assert collated_predictor_targets.size(0) == batch_size, "batch_size mismatch (collated_predictor_targets)"
+        assert collated_predictor_targets.size(1) == n_patch, "patch count mismatch (collated_predictor_targets)"
+        assert collated_predictor_targets.dtype == torch.bool, "dtype mismatch (collated_predictor_targets)"
 
         # check that at least min_keep patches are unmasked for encoder
         assert (
-            torch.sum(~collated_masks_for_context_encoder, dim=1).min() >= collator.min_keep
+            torch.sum(~collated_encoder_masks, dim=1).min() >= collator.min_keep
         ), "min_keep not satisfied for encoder"
 
-        # check that at least one patch is unmasked for predictor
-        assert torch.sum(~collated_masks_for_predictor, dim=1).min() > 0, "no prediction target for predictor"
+        # check that at least one patch is masked for predictor target
+        assert torch.sum(collated_predictor_targets, dim=1).min() > 0, "no prediction target for predictor"
 
-        # check that encoder and predictor masks are not identical
+        # check that encoder masks and predictor targets are not identical
         assert not torch.all(
-            collated_masks_for_context_encoder == collated_masks_for_predictor
-        ), "encoder and predictor masks are identical"
+            collated_encoder_masks == collated_predictor_targets
+        ), "encoder masks and predictor targets are identical"
+
+    def test_sample_masks_and_target(self):
+        image_size, patch_size = 224, 16
+        collator = BoolIJEPAMultiBlockMaskCollator(
+            input_size=(image_size, image_size),
+            patch_size=(patch_size, patch_size),
+            n_masks=4,
+            min_keep=50,
+        )
+        g = torch.Generator()
+        encoder_mask, predictor_target = collator.sample_masks_and_target(g)
+
+        n_patches = (image_size // patch_size) ** 2
+
+        assert encoder_mask.shape == (n_patches,)
+        assert predictor_target.shape == (n_patches,)
+        assert encoder_mask.dtype == torch.bool
+        assert predictor_target.dtype == torch.bool
+
+        # Check that at least min_keep patches are unmasked for encoder
+        assert torch.sum(~encoder_mask) >= collator.min_keep
+
+        # Check that at least one patch is masked for predictor target
+        assert torch.sum(predictor_target) > 0
+
+        # Check that encoder mask and predictor target are not identical
+        assert not torch.all(encoder_mask == predictor_target)

--- a/tests/trainers/test_bool_mask_i_jepa_trainer.py
+++ b/tests/trainers/test_bool_mask_i_jepa_trainer.py
@@ -10,7 +10,7 @@ from ami.data.buffers.buffer_names import BufferNames
 from ami.data.buffers.random_data_buffer import RandomDataBuffer
 from ami.data.step_data import DataKeys, StepData
 from ami.data.utils import DataCollectorsDict
-from ami.models.bool_mask_i_jepa import BoolMaskIJEPAEncoder, BoolMaskIJEPAPredictor
+from ami.models.bool_mask_i_jepa import BoolMaskIJEPAEncoder, BoolTargetIJEPAPredictor
 from ami.models.model_names import ModelNames
 from ami.models.model_wrapper import ModelWrapper
 from ami.models.utils import ModelWrappersDict
@@ -70,8 +70,8 @@ class TestBoolMaskIJEPATrainer:
         )
 
     @pytest.fixture
-    def bool_mask_i_jepa_predictor(self):
-        return BoolMaskIJEPAPredictor(
+    def bool_target_i_jepa_predictor(self):
+        return BoolTargetIJEPAPredictor(
             n_patches=(IMAGE_SIZE // PATCH_SIZE, IMAGE_SIZE // PATCH_SIZE),
             context_encoder_out_dim=ENCODER_EMBEDDING_DIM,
             hidden_dim=PREDICTOR_HIDDEN_DIM,
@@ -100,12 +100,12 @@ class TestBoolMaskIJEPATrainer:
         self,
         device: torch.device,
         bool_mask_i_jepa_encoder: BoolMaskIJEPAEncoder,
-        bool_mask_i_jepa_predictor: BoolMaskIJEPAPredictor,
+        bool_target_i_jepa_predictor: BoolTargetIJEPAPredictor,
     ) -> ModelWrappersDict:
         d = ModelWrappersDict(
             {
                 ModelNames.I_JEPA_CONTEXT_ENCODER: ModelWrapper(bool_mask_i_jepa_encoder, device, has_inference=False),
-                ModelNames.I_JEPA_PREDICTOR: ModelWrapper(bool_mask_i_jepa_predictor, device, has_inference=False),
+                ModelNames.I_JEPA_PREDICTOR: ModelWrapper(bool_target_i_jepa_predictor, device, has_inference=False),
                 ModelNames.I_JEPA_TARGET_ENCODER: ModelWrapper(
                     copy.deepcopy(bool_mask_i_jepa_encoder), device, has_inference=True
                 ),


### PR DESCRIPTION
## 概要

#59 に関連して、BoolMaskIJEPAPredictorをBoolTargetIJEPAPredictorにリファクタリングした。
スムーズな処理フロー的には、predictorの予測対象「マスク」は「ターゲット」とした方が直感的である。

また、Predictorに予測位置を示すことができれば良いため、ターゲット予測位置にそれを表すベクトルを加算する仕様に変更した。
これにより、Predictorにおいて最大1/2~1/3程度の計算量の低下が見込まれる。

## 変更内容

<!-- ビューの変更がある場合はスクショによる比較などがあるとわかりやすい -->

## 影響範囲

<!-- この関数を変更したのでこの機能にも影響がある、など -->

## Submit前の確認項目

<!-- PRをSubmitする前に確認する項目 -->

- [x] タイトルは一目でわかるようにし、説明文は PR を簡潔に説明するようにしましたか?
- [x] あなたの PR が、異なる変更を束ねたものではなく、ひとつのことだけを行うものであることを確認しましたか?
- [x] この PR で導入されたすべての変更点をリストアップしましたか?
- [x] PR を`make run`コマンドでローカルでテストしましたか?

## 補足

<!-- レビューをする際に見てほしい点、ローカル環境で試す際の注意点、など -->
