### PR TITLE
I-JEPAをデータセットで学習

### DIFF
--- a/ami/trainers/bool_mask_i_jepa_trainer.py
+++ b/ami/trainers/bool_mask_i_jepa_trainer.py
@@ -127,6 +127,7 @@ class BoolMaskIJEPATrainer(BaseTrainer):
                 losses = torch.masked_fill(losses, ~targets_for_predictor, 0.0)
                 loss = losses.sum() / targets_for_predictor.sum()
 
+                self.logger.log("i-jepa/target-encoder-latent-std", latent_from_target_encoder.std(0).mean())
                 self.logger.log("i-jepa/loss", loss)
                 loss.backward()
                 optimizer.step()

--- a/ami/trainers/bool_mask_i_jepa_trainer.py
+++ b/ami/trainers/bool_mask_i_jepa_trainer.py
@@ -127,8 +127,8 @@ class BoolMaskIJEPATrainer(BaseTrainer):
                 losses = torch.masked_fill(losses, ~targets_for_predictor, 0.0)
                 loss = losses.sum() / targets_for_predictor.sum()
 
-                self.logger.log("i-jepa/target-encoder-latent-std", latent_from_target_encoder.std(0).mean())
-                self.logger.log("i-jepa/loss", loss)
+                self.logger.log("i-jepa/metrics/target-encoder-latent-std", latent_from_target_encoder.std(0).mean())
+                self.logger.log("i-jepa/losses/smooth-l1", loss)
                 loss.backward()
                 optimizer.step()
                 self.logger.update()

--- a/ami/trainers/i_jepa_trainer.py
+++ b/ami/trainers/i_jepa_trainer.py
@@ -142,7 +142,7 @@ class IJEPATrainer(BaseTrainer):
                     latent_from_target_encoder,
                     reduction="mean",
                 )
-                self.logger.log("i-jepa/batch-wise-target-encoder-latent-std", latent_from_predictor.std(0).mean())
+                self.logger.log("i-jepa/target-encoder-latent-std", latent_from_predictor.std(0).mean())
                 self.logger.log("i-jepa/loss", loss)
                 optimizer.zero_grad()
                 loss.backward()
@@ -152,8 +152,8 @@ class IJEPATrainer(BaseTrainer):
                     for p in itertools.chain(self.context_encoder.parameters(), self.predictor.parameters())
                     if p.grad is not None
                 ]
-                grad_norm = torch.cat(flatten_grads).norm(1)
-                self.logger.log("i-jepa/l1gradnorm", grad_norm)
+                grad_mean = torch.cat(flatten_grads).mean()
+                self.logger.log("i-jepa/l1-grad-mean-value", grad_mean)
                 optimizer.step()
                 # target_encoder updates weights by moving average from context_encoder
                 with torch.no_grad():

--- a/ami/trainers/i_jepa_trainer.py
+++ b/ami/trainers/i_jepa_trainer.py
@@ -147,13 +147,13 @@ class IJEPATrainer(BaseTrainer):
                 optimizer.zero_grad()
                 loss.backward()
                 # log grad
-                flatten_grads = [
-                    p.grad.flatten()
-                    for p in itertools.chain(self.context_encoder.parameters(), self.predictor.parameters())
-                    if p.grad is not None
-                ]
-                grad_norm = torch.cat(flatten_grads).norm(1)
-                self.logger.log("i-jepa/l1gradnorm", grad_norm)
+                # flatten_grads = [
+                #     p.grad.flatten()
+                #     for p in itertools.chain(self.context_encoder.parameters(), self.predictor.parameters())
+                #     if p.grad is not None
+                # ]
+                # grad_norm = torch.cat(flatten_grads).norm(1)
+                # self.logger.log("i-jepa/l1gradnorm", grad_norm)
                 optimizer.step()
                 # target_encoder updates weights by moving average from context_encoder
                 with torch.no_grad():

--- a/ami/trainers/i_jepa_trainer.py
+++ b/ami/trainers/i_jepa_trainer.py
@@ -131,7 +131,7 @@ class IJEPATrainer(BaseTrainer):
                     images=image_batch, patch_selections_for_context_encoder=masks_for_context_encoder
                 )
                 # predictor
-                latent_from_predictor: torch.Tensor = self.predictor(
+                latent_from_predictor = self.predictor(
                     latents=latent_from_context_encoder,
                     patch_selections_for_context_encoder=masks_for_context_encoder,
                     patch_selections_for_predictor=masks_for_predictor,
@@ -142,7 +142,7 @@ class IJEPATrainer(BaseTrainer):
                     latent_from_target_encoder,
                     reduction="mean",
                 )
-                self.logger.log("i-jepa/target-encoder-latent-std", latent_from_predictor.std(0).mean())
+                self.logger.log("i-jepa/target-encoder-latent-std", latent_from_target_encoder.std(0).mean())
                 self.logger.log("i-jepa/loss", loss)
                 optimizer.zero_grad()
                 loss.backward()

--- a/ami/trainers/i_jepa_trainer.py
+++ b/ami/trainers/i_jepa_trainer.py
@@ -142,8 +142,8 @@ class IJEPATrainer(BaseTrainer):
                     latent_from_target_encoder,
                     reduction="mean",
                 )
-                self.logger.log("i-jepa/target-encoder-latent-std", latent_from_target_encoder.std(0).mean())
-                self.logger.log("i-jepa/loss", loss)
+                self.logger.log("i-jepa/metrics/target-encoder-latent-std", latent_from_target_encoder.std(0).mean())
+                self.logger.log("i-jepa/losses/smooth-l1", loss)
                 optimizer.zero_grad()
                 loss.backward()
                 # log grad

--- a/ami/trainers/i_jepa_trainer.py
+++ b/ami/trainers/i_jepa_trainer.py
@@ -152,7 +152,7 @@ class IJEPATrainer(BaseTrainer):
                     for p in itertools.chain(self.context_encoder.parameters(), self.predictor.parameters())
                     if p.grad is not None
                 ]
-                grad_mean = torch.cat(flatten_grads).mean()
+                grad_mean = torch.cat(flatten_grads).abs().mean()
                 self.logger.log("i-jepa/l1-grad-mean-value", grad_mean)
                 optimizer.step()
                 # target_encoder updates weights by moving average from context_encoder

--- a/ami/trainers/i_jepa_trainer.py
+++ b/ami/trainers/i_jepa_trainer.py
@@ -152,8 +152,8 @@ class IJEPATrainer(BaseTrainer):
                     for p in itertools.chain(self.context_encoder.parameters(), self.predictor.parameters())
                     if p.grad is not None
                 ]
-                grad_mean = torch.cat(flatten_grads).abs().mean()
-                self.logger.log("i-jepa/l1-grad-mean-value", grad_mean)
+                grad_norm = torch.cat(flatten_grads).norm(1)
+                self.logger.log("i-jepa/l1gradnorm", grad_norm)
                 optimizer.step()
                 # target_encoder updates weights by moving average from context_encoder
                 with torch.no_grad():

--- a/ami/trainers/i_jepa_trainer.py
+++ b/ami/trainers/i_jepa_trainer.py
@@ -131,7 +131,7 @@ class IJEPATrainer(BaseTrainer):
                     images=image_batch, patch_selections_for_context_encoder=masks_for_context_encoder
                 )
                 # predictor
-                latent_from_predictor = self.predictor(
+                latent_from_predictor: torch.Tensor = self.predictor(
                     latents=latent_from_context_encoder,
                     patch_selections_for_context_encoder=masks_for_context_encoder,
                     patch_selections_for_predictor=masks_for_predictor,
@@ -142,7 +142,7 @@ class IJEPATrainer(BaseTrainer):
                     latent_from_target_encoder,
                     reduction="mean",
                 )
-                self.logger.log("i-jepa/target-encoder-latent-std", latent_from_predictor.std())
+                self.logger.log("i-jepa/batch-wise-target-encoder-latent-std", latent_from_predictor.std(0).mean())
                 self.logger.log("i-jepa/loss", loss)
                 optimizer.zero_grad()
                 loss.backward()

--- a/configs/experiment/bool_mask_i_jepa_with_dataset.yaml
+++ b/configs/experiment/bool_mask_i_jepa_with_dataset.yaml
@@ -1,0 +1,13 @@
+# @package _global_
+
+defaults:
+  - bool_mask_i_jepa
+  - override /interaction/environment: image_dataset
+
+interaction:
+  environment:
+    observation_generator:
+      root_dir: ${image_data_dir}
+
+image_data_dir: ??? # Specify as command line argument. `python launch.py experiment=<experiment file name> image_data_dir=<path/to/image_data>
+task_name: bool_mask_i_jepa_with_dataset

--- a/configs/experiment/i_jepa_with_dataset.yaml
+++ b/configs/experiment/i_jepa_with_dataset.yaml
@@ -1,0 +1,13 @@
+# @package _global_
+
+defaults:
+  - i_jepa
+  - override /interaction/environment: image_dataset
+
+interaction:
+  environment:
+    observation_generator:
+      root_dir: ${image_data_dir}
+
+image_data_dir: ??? # Specify as command line argument. `python launch.py experiment=<experiment file name> image_data_dir=<path/to/image_data>
+task_name: i_jepa_with_dataset

--- a/configs/interaction/environment/image_dataset.yaml
+++ b/configs/interaction/environment/image_dataset.yaml
@@ -1,0 +1,14 @@
+_target_: ami.interactions.environments.dummy_environment.DummyEnvironment
+
+observation_generator:
+  _target_: ami.interactions.environments.image_folder_observation_generator.ImageFolderObservationGenerator
+  root_dir: ??? # Please specify dataset dir.
+  image_size:
+    - ${shared.image_height}
+    - ${shared.image_width}
+
+action_checker:
+  _target_: ami.interactions.environments.dummy_environment.ActionTypeChecker
+  action_type:
+    _target_: hydra.utils.get_class
+    path: torch.Tensor

--- a/configs/trainers/i_jepa/default.yaml
+++ b/configs/trainers/i_jepa/default.yaml
@@ -36,3 +36,4 @@ device: ${devices.0}
 max_epochs: 3
 minimum_dataset_size: ${.partial_dataloader.batch_size}
 minimum_new_data_count: 128 # From primitive ami.
+target_encoder_update_moving_average: 0.996

--- a/tests/test_configs.py
+++ b/tests/test_configs.py
@@ -20,7 +20,7 @@ LAUNCH_CONFIG = "launch.yaml"
 EXPERIMENT_CONFIG_DIR = CONFIG_DIR / "experiment"
 EXPERIMENT_CONFIG_FILES = EXPERIMENT_CONFIG_DIR.glob("*.*")
 
-IGNORE_EXPERIMENT_CONFIGS = {"unity_sioconv.yaml", "dreamer_unity.yaml"}
+IGNORE_EXPERIMENT_CONFIGS = {"unity_sioconv.yaml", "dreamer_unity.yaml", "i_jepa_with_dataset.yaml"}
 EXPERIMENT_CONFIG_OVERRIDES = [
     [f"experiment={file.name.rsplit('.', 1)[0]}"]
     for file in EXPERIMENT_CONFIG_FILES

--- a/tests/test_configs.py
+++ b/tests/test_configs.py
@@ -20,7 +20,12 @@ LAUNCH_CONFIG = "launch.yaml"
 EXPERIMENT_CONFIG_DIR = CONFIG_DIR / "experiment"
 EXPERIMENT_CONFIG_FILES = EXPERIMENT_CONFIG_DIR.glob("*.*")
 
-IGNORE_EXPERIMENT_CONFIGS = {"unity_sioconv.yaml", "dreamer_unity.yaml", "i_jepa_with_dataset.yaml"}
+IGNORE_EXPERIMENT_CONFIGS = {
+    "unity_sioconv.yaml",
+    "dreamer_unity.yaml",
+    "i_jepa_with_dataset.yaml",
+    "bool_mask_i_jepa_with_dataset.yaml",
+}
 EXPERIMENT_CONFIG_OVERRIDES = [
     [f"experiment={file.name.rsplit('.', 1)[0]}"]
     for file in EXPERIMENT_CONFIG_FILES


### PR DESCRIPTION
## 概要

I-JEPA をデータセットで学習させ、どのように収束するか確認した際の変更差分。
moving averageの値を変更したり、潜在空間が意味あるものかどうかを確認するために Batch方向に対してstdをとったりして情報を収集した。stdの記録はその後も学習メトリクスに有効と考えたためそのまま残した。

学習データセットは OpenImagesV7のValidationデータセットを用いた。

## 変更内容

<!-- ビューの変更がある場合はスクショによる比較などがあるとわかりやすい -->

## 影響範囲

<!-- この関数を変更したのでこの機能にも影響がある、など -->

## Submit前の確認項目

<!-- PRをSubmitする前に確認する項目 -->

- [x] タイトルは一目でわかるようにし、説明文は PR を簡潔に説明するようにしましたか?
- [x] あなたの PR が、異なる変更を束ねたものではなく、ひとつのことだけを行うものであることを確認しましたか?
- [x] この PR で導入されたすべての変更点をリストアップしましたか?
- [x] PR を`make run`コマンドでローカルでテストしましたか?

## 補足

<!-- レビューをする際に見てほしい点、ローカル環境で試す際の注意点、など -->
