### PR TITLE
Dreamerの未学習問題を修正

### DIFF
--- a/ami/interactions/agents/multi_step_imagination_curiosity_agent.py
+++ b/ami/interactions/agents/multi_step_imagination_curiosity_agent.py
@@ -80,8 +80,8 @@ class MultiStepImaginationCuriosityImageAgent(BaseAgent[Tensor, Tensor]):
             )
             reward = self.reward_average_method(reward_imaginations)
             self.logger.log("agent/reward", reward)
-            for i, r in enumerate(reward_imaginations, start=1):
-                self.logger.log(f"agent/reward_{i}step", r)
+            # for i, r in enumerate(reward_imaginations, start=1):
+            #     self.logger.log(f"agent/reward_{i}step", r)
 
             # ステップの冒頭でデータコレクトすることで前ステップのデータを収集する。
             self.step_data[DataKeys.REWARD] = reward

--- a/ami/trainers/dreaming_policy_value_trainer.py
+++ b/ami/trainers/dreaming_policy_value_trainer.py
@@ -202,7 +202,8 @@ class DreamingPolicyValueTrainer(BaseTrainer):
                 # Update policy network
                 policy_optimizer.zero_grad()
                 entropy_loss = trajectory["action_entropies"].mean()
-                return_loss = returns.mean()
+                return_loss = returns.sum(0).mean()
+                mean_return = returns.mean()
                 policy_loss = -(return_loss + entropy_loss * self.entropy_coef)  # maximize.
                 policy_loss.backward()
                 policy_grad_norm = torch.cat(
@@ -231,6 +232,7 @@ class DreamingPolicyValueTrainer(BaseTrainer):
 
                 # Logging
                 self.logger.log(prefix + "return", return_loss)
+                self.logger.log(prefix + "mean_return", mean_return)
                 self.logger.log(prefix + "entropy", entropy_loss)
                 self.logger.log(prefix + "policy_loss", policy_loss)
                 self.logger.log(prefix + "value_loss", value_loss)

--- a/ami/trainers/ppo_policy_trainer.py
+++ b/ami/trainers/ppo_policy_trainer.py
@@ -157,6 +157,10 @@ class PPOPolicyTrainer(BaseTrainer):
 
                 optimizer.zero_grad()
                 out["loss"].backward()
+                grad_norm = torch.cat(
+                    [p.grad.flatten() for p in self.policy_value.parameters() if p.grad is not None]
+                ).norm()
+                self.logger.log("ppo_policy/grad_norm", grad_norm)
                 optimizer.step()
                 self.logger.update()
 

--- a/configs/experiment/dreamer_multi_step_imagination_unity.yaml
+++ b/configs/experiment/dreamer_multi_step_imagination_unity.yaml
@@ -1,0 +1,15 @@
+# @package _global_
+
+defaults:
+  - dreamer_multi_step_imagination
+  - override /interaction/environment: unity
+
+interaction:
+  environment:
+    file_path: ${unity_env_path}
+    worker_id: ${unity_worker_id}
+
+unity_env_path: ??? # Please specify the arg `unity_env_path='<path/to/executable>'
+unity_worker_id: 0 # Please increment this value when launching multiple experience.
+
+task_name: dreamer_multi_step_imagination_unity

--- a/configs/experiment/world_models_sioconv_lerp_hidden_unity.yaml
+++ b/configs/experiment/world_models_sioconv_lerp_hidden_unity.yaml
@@ -1,0 +1,13 @@
+# @package _global_
+
+defaults:
+  - world_models_sioconv
+  - override /interaction/environment: unity
+
+interaction:
+  environment:
+    file_path: ${unity_env_path}
+    worker_id: ${unity_worker_id}
+
+unity_env_path: ??? # Please specify the arg `unity_env_path='<path/to/executable>'
+unity_worker_id: 0 # Please increment this value when launching multiple experience.

--- a/configs/models/dreamer.yaml
+++ b/configs/models/dreamer.yaml
@@ -130,7 +130,10 @@ value:
       dim_hidden: 1024
       depth: 4
     dist_head:
-      _target_: ami.models.components.fully_connected_normal.FullyConnectedNormal
+      _target_: ami.models.components.fully_connected_fixed_std_normal.FullyConnectedFixedStdNormal
       dim_in: ${..observation_hidden_projection.dim_out}
       dim_out: 1
       squeeze_feature_dim: True
+      normal_cls:
+        _target_: hydra.utils.get_class
+        path: ami.models.components.fully_connected_fixed_std_normal.DeterministicNormal

--- a/configs/trainers/dreaming_policy_value/default.yaml
+++ b/configs/trainers/dreaming_policy_value/default.yaml
@@ -19,19 +19,7 @@ partial_value_optimizer:
   lr: 1e-4
   betas: [0.9, 0.999]
 
-partial_policy_lr_scheduler:
-  _target_: ami.trainers.dreaming_policy_value_trainer.InitialMultiplicationLRScheduler
-  _partial_: true
-  multiplication_factor: 0.0
-  initial_epochs: ${python.eval:"50 * ${..max_epochs}"} # 大体10分くらい。
-  verbose: true
-
-partial_value_lr_scheduler:
-  _target_: ami.trainers.dreaming_policy_value_trainer.InitialMultiplicationLRScheduler
-  _partial_: true
-  multiplication_factor: 0.0
-  initial_epochs: ${python.eval:"50 * ${..max_epochs}"} # 大体10分くらい。
-  verbose: true
+update_start_train_count: 50
 
 logger:
   _target_: ami.tensorboard_loggers.StepIntervalLogger

--- a/configs/trainers/dreaming_policy_value/default.yaml
+++ b/configs/trainers/dreaming_policy_value/default.yaml
@@ -10,13 +10,13 @@ partial_dataloader:
 partial_policy_optimizer:
   _target_: torch.optim.Adam
   _partial_: true
-  lr: 1e-4
+  lr: 1e-5
   betas: [0.9, 0.999]
 
 partial_value_optimizer:
   _target_: torch.optim.Adam
   _partial_: true
-  lr: 1e-4
+  lr: 1e-5
   betas: [0.9, 0.999]
 
 update_start_train_count: 50

--- a/tests/test_configs.py
+++ b/tests/test_configs.py
@@ -25,6 +25,7 @@ IGNORE_EXPERIMENT_CONFIGS = {
     "dreamer_unity.yaml",
     "i_jepa_with_dataset.yaml",
     "bool_mask_i_jepa_with_dataset.yaml",
+    "world_models_sioconv_lerp_hidden_unity.yaml",
 }
 EXPERIMENT_CONFIG_OVERRIDES = [
     [f"experiment={file.name.rsplit('.', 1)[0]}"]

--- a/tests/trainers/test_dreaming_policy_value_trainer.py
+++ b/tests/trainers/test_dreaming_policy_value_trainer.py
@@ -172,6 +172,7 @@ class TestDreamingPolicyValueTrainer:
         assert (trainer_path / "policy_lr_scheduler.pt").exists()
         assert (trainer_path / "value_lr_scheduler.pt").exists()
         assert (trainer_path / "logger.pt").exists()
+        assert (trainer_path / "current_train_count.pt").exists()
         logger_state = trainer.logger.state_dict()
 
         mocked_logger_load_state_dict = mocker.spy(trainer.logger, "load_state_dict")
@@ -179,16 +180,19 @@ class TestDreamingPolicyValueTrainer:
         trainer.value_optimizer_state.clear()
         trainer.policy_lr_scheduler_state.clear()
         trainer.value_lr_scheduler_state.clear()
+        trainer._current_train_count = -1
         assert trainer.policy_optimizer_state == {}
         assert trainer.value_optimizer_state == {}
         assert trainer.policy_lr_scheduler_state == {}
         assert trainer.value_lr_scheduler_state == {}
+        assert trainer._current_train_count == -1
         trainer.load_state(trainer_path)
         assert trainer.policy_optimizer_state != {}
         assert trainer.value_optimizer_state != {}
         assert trainer.policy_lr_scheduler_state != {}
         assert trainer.value_lr_scheduler_state != {}
         mocked_logger_load_state_dict.assert_called_once_with(logger_state)
+        assert trainer._current_train_count == 0
 
 
 class TestInitialMultiplicationLRScheduler:


### PR DESCRIPTION
## 概要

#72 
* LRSchedulerではなく Trainerに学習遅延機能を実装しました。
* PPOと比較した際に、Policyの勾配の大きさが小さかったため、returnを時間軸meanからsumに戻しました。
* 学習率を1e-5にしたら安定して学習するようになりました。もっと小さい方がいいかもしれません。

## 変更内容

<!-- ビューの変更がある場合はスクショによる比較などがあるとわかりやすい -->

## 影響範囲

<!-- この関数を変更したのでこの機能にも影響がある、など -->

## Submit前の確認項目

<!-- PRをSubmitする前に確認する項目 -->

- [x] タイトルは一目でわかるようにし、説明文は PR を簡潔に説明するようにしましたか?
- [x] あなたの PR が、異なる変更を束ねたものではなく、ひとつのことだけを行うものであることを確認しましたか?
- [x] この PR で導入されたすべての変更点をリストアップしましたか?
- [x] PR を`make run`コマンドでローカルでテストしましたか?

## 補足

<!-- レビューをする際に見てほしい点、ローカル環境で試す際の注意点、など -->
