### PR TITLE
PPO Dreamerのラージサイズを実装

### DIFF
--- a/configs/experiment/i_jepa_sioconv_ppodreamer_multi_step_large.yaml
+++ b/configs/experiment/i_jepa_sioconv_ppodreamer_multi_step_large.yaml
@@ -1,0 +1,80 @@
+# @package _global_
+
+# ここに記述されるハイパーパラメータは、 RTX 4090を最大限使用する設定です。
+# 制約条件
+# - VRAM 24GB
+# - 1度のTraining Timeの合計時間が 12.8秒以下
+# - 10 FPSで推論動作
+
+defaults:
+  - i_jepa_sioconv_ppodreamer_multi_step
+
+shared:
+  image_height: 144
+  image_width: 144
+
+interaction:
+  agent:
+    max_imagination_steps: 50 # 5 sec
+
+models:
+  i_jepa_target_encoder:
+    model:
+      patch_size: 12
+      embed_dim: 648
+      out_dim: 32
+      depth: 12
+      num_heads: 9
+  i_jepa_predictor:
+    model:
+      hidden_dim: 324
+      depth: 12
+      num_heads: 4
+  forward_dynamics:
+    model:
+      observation_flatten:
+        dim_out: 2048
+      core_model:
+        depth: 12
+        dim: 2048
+        dim_ff_hidden: ${python.eval:"${.dim} * 2"}
+  policy_value:
+    model:
+      observation_projection:
+        dim_out: 1024
+      observation_hidden_projection:
+        dim_out: 1024
+      core_model:
+        dim_hidden: 1024
+        depth: 8
+
+data_collectors:
+  image:
+    max_len: ${python.eval:"24 * ${trainers.i_jepa.partial_dataloader.batch_size}"}
+  forward_dynamics_trajectory:
+    max_len: ${python.eval:"20 * ${trainers.forward_dynamics.partial_dataloader.batch_size}"}
+  dreaming_initial_states:
+    max_len: ${python.eval:"16 * ${trainers.dreaming_policy_value.partial_dataloader.batch_size}"}
+
+trainers:
+  i_jepa:
+    max_epochs: 1
+    partial_dataloader:
+      batch_size: 32
+    minimum_new_data_count: 128
+
+  forward_dynamics:
+    max_epochs: 1
+    partial_dataloader:
+      batch_size: ${python.eval:"256 + 1"}
+    minimum_new_data_count: 128
+
+  dreaming_policy_value:
+    update_start_train_count: 50
+    max_epochs: 1
+    partial_dataloader:
+      batch_size: 64
+    minimum_new_data_count: 128
+    imagination_temperature: 1.0
+
+task_name: i_jepa_sioconv_ppodreamer_multi_step_large

--- a/configs/launch.yaml
+++ b/configs/launch.yaml
@@ -34,3 +34,5 @@ log_level: INFO
 time_scale: 1.0
 
 max_uptime: inf # This value will scale by `time_scale`.
+
+torch_float32_matmul_precision: "high" # Using tensor core.

--- a/scripts/launch.py
+++ b/scripts/launch.py
@@ -3,6 +3,7 @@ import os
 
 import hydra
 import rootutils
+import torch
 from omegaconf import DictConfig, open_dict
 
 from ami.checkpointing.checkpoint_schedulers import BaseCheckpointScheduler
@@ -39,6 +40,8 @@ register_custom_resolvers()
 @hydra.main(config_path="../configs", config_name="launch", version_base="1.3")
 def main(cfg: DictConfig) -> None:
     logger.info("Launch AMI.")
+    if precision := cfg.get("torch_float32_matmul_precision"):
+        torch.set_float32_matmul_precision(precision)
 
     logger.info(f"Instantiating Interaction <{cfg.interaction._target_}>")
     interaction: Interaction = hydra.utils.instantiate(cfg.interaction)


### PR DESCRIPTION
## 概要

PPO DreamerでP-AMI<Q>の最大サイズを実装しました。
どうしても推論速度が10FPSを切ってしまったため、 `torch.set_float32_matmul_precision`を設定し、Tensor Coreを用いるようにして解決しました。

## 変更内容

<!-- ビューの変更がある場合はスクショによる比較などがあるとわかりやすい -->

## 影響範囲

<!-- この関数を変更したのでこの機能にも影響がある、など -->

## Submit前の確認項目

<!-- PRをSubmitする前に確認する項目 -->

- [x] タイトルは一目でわかるようにし、説明文は PR を簡潔に説明するようにしましたか?
- [x] あなたの PR が、異なる変更を束ねたものではなく、ひとつのことだけを行うものであることを確認しましたか?
- [x] この PR で導入されたすべての変更点をリストアップしましたか?
- [x] PR を`make run`コマンドでローカルでテストしましたか?

## 補足

<!-- レビューをする際に見てほしい点、ローカル環境で試す際の注意点、など -->
