### PR TITLE
VideoFoldersImageObservationGeneratorを根本的に修正

### DIFF
--- a/ami/interactions/environments/video_folders_image_observation_generator.py
+++ b/ami/interactions/environments/video_folders_image_observation_generator.py
@@ -1,159 +1,147 @@
-import warnings
 from pathlib import Path
+from typing import Iterator
 
 import cv2
 import torch
-from torchvision.transforms import v2
 
 
-class VideoFoldersImageObservationGenerator:
-    """A generator class that provides image observations from multiple video
-    folders.
-
-    This class reads video files from specified folders, processes them
-    frame by frame, and yields image tensors as observations. It
-    supports multiple video formats, custom start frames, and frame
-    limits per video folder.
-    """
+class FolderAsVideo:
+    """Handles a folder of video files sequentially as if it were a single
+    video file."""
 
     def __init__(
         self,
-        folders: list[str | Path],
-        image_size: tuple[int, int],
+        folder: str | Path,
         extensions: tuple[str, ...] = ("mp4",),
-        start_frame_per_videos: int | list[int] = 0,
-        video_frames_per_videos: int | None | list[int | None] = None,
-    ):
-        """Initialize the VideoFoldersImageObservationGenerator.
+        sort_by_name: bool = True,
+        start_frame: int = 0,
+        max_frames: int | None = None,
+    ) -> None:
+        """Initialize the FolderAsVideo object.
 
         Args:
-            folders (list[str | Path]): List of folder paths containing video files.
-            image_size (tuple[int, int]): Target size for output images (height, width).
-            extensions (tuple[str, ...], optional): Tuple of video file extensions to consider. Defaults to ("mp4",).
-            start_frame_per_videos (int | list[int], optional): Starting frame(s) for each video folder. Defaults to 0.
-            video_frames_per_videos (int | None | list[int | None], optional): Number of frames to use from each video folder.
-                                                                               None means use all available frames. Defaults to None.
+            folder (str | Path): Path to the folder containing video files.
+            extensions (tuple[str, ...]): Tuple of video file extensions to consider.
+            sort_by_name (bool): Whether to sort video files by name.
+            start_frame (int): The frame number to start reading from.
+            max_frames (int | None): Maximum number of frames to read. If None, read all available frames.
+
+        Raises:
+            ValueError: If start_frame is greater than or equal to total frames,
+                        or if max_frames exceeds available frames.
         """
-        self.folders = [Path(folder) for folder in folders]
-        self.image_size = image_size
+        self.folder = Path(folder)
         self.extensions = extensions
+        self.start_frame = start_frame
 
-        # Validate and set start_frame_per_videos
-        if isinstance(start_frame_per_videos, list):
-            assert len(start_frame_per_videos) == len(
-                self.folders
-            ), "Length of start_frame_per_videos must match the number of folders"
-            self.start_frame_per_videos = start_frame_per_videos
+        self.video_files = self._get_video_files(sort_by_name)
+        self.total_frames = self._count_total_frames()
+
+        if self.start_frame >= self.total_frames:
+            raise ValueError(f"start_frame ({self.start_frame}) must be less than total frames ({self.total_frames})")
+
+        self.available_frames = self.total_frames - self.start_frame
+
+        if max_frames is None:
+            self.max_frames = self.available_frames
         else:
-            self.start_frame_per_videos = [start_frame_per_videos] * len(self.folders)
+            if max_frames > self.available_frames:
+                raise ValueError(f"max_frames ({max_frames}) exceeds available frames ({self.available_frames})")
+            self.max_frames = max_frames
 
-        # Validate video_frames_per_videos
-        if isinstance(video_frames_per_videos, list):
-            assert len(video_frames_per_videos) == len(
-                self.folders
-            ), "Length of video_frames_per_videos must match the number of folders"
-        elif video_frames_per_videos is None:
-            video_frames_per_videos = [None] * len(self.folders)
-        else:
-            video_frames_per_videos = [video_frames_per_videos] * len(self.folders)
-
-        self.video_files = self._get_sorted_video_files()
-        self.video_frames_per_videos = self._process_video_frames(video_frames_per_videos)
-
-        self.current_folder_index = 0
         self.current_video_index = 0
-        self.current_frame_index = 0
-        self.current_video: cv2.VideoCapture | None = None
+        self.current_frame = 0
+        self.current_video = None
+        self._initialize_video()
 
-        self._load_next_video()
-
-    def _get_sorted_video_files(self) -> list[list[Path]]:
+    def _get_video_files(self, sort_by_name: bool) -> list[Path]:
+        """Get a list of video files in the folder."""
         video_files = []
-        for folder in self.folders:
-            folder_files = []
-            for ext in self.extensions:
-                folder_files.extend(sorted(folder.glob(f"*.{ext}")))
-            video_files.append(folder_files)
-        return video_files
+        for ext in self.extensions:
+            video_files.extend(self.folder.glob(f"*.{ext}"))
+        return sorted(video_files) if sort_by_name else video_files
 
-    def _process_video_frames(self, video_frames_per_videos: list[int | None]) -> list[int]:
-        processed_frames = []
-        for folder_index, folder_files in enumerate(self.video_files):
-            total_frames = 0
-            for file in folder_files:
-                cap = cv2.VideoCapture(str(file))
-                total_frames += int(cap.get(cv2.CAP_PROP_FRAME_COUNT))
-                cap.release()
+    def _count_total_frames(self) -> int:
+        """Count the total number of frames across all video files."""
+        total = 0
+        for video_file in self.video_files:
+            cap = self._open_video_file(video_file)
+            total += int(cap.get(cv2.CAP_PROP_FRAME_COUNT))
+            cap.release()
+        return total
 
-            start_frame = self.start_frame_per_videos[folder_index]
-            available_frames = total_frames - start_frame
+    @staticmethod
+    def _open_video_file(path: Path) -> cv2.VideoCapture:
+        """Open a video file and return the VideoCapture object."""
+        cap = cv2.VideoCapture(str(path))
+        if not cap.isOpened():
+            raise RuntimeError(f"Cannot open video file '{path}'")
+        return cap
 
-            requested_frames = video_frames_per_videos[folder_index]
-            if requested_frames is None:
-                processed_frames.append(available_frames)
-            else:
-                assert requested_frames <= available_frames, (
-                    f"Folder {self.folders[folder_index]} has fewer available frames ({available_frames}) "
-                    f"than requested ({requested_frames})"
-                )
-                processed_frames.append(requested_frames)
+    def _initialize_video(self) -> None:
+        """Initialize the video to the correct file and frame position."""
+        remaining_frames = self.start_frame
+        for i, video_file in enumerate(self.video_files):
+            cap = self._open_video_file(video_file)
+            frames_in_video = int(cap.get(cv2.CAP_PROP_FRAME_COUNT))
+            if remaining_frames < frames_in_video:
+                cap.set(cv2.CAP_PROP_POS_FRAMES, remaining_frames)
+                self.current_video = cap
+                self.current_video_index = i
+                self.current_frame = self.start_frame
+                return
+            remaining_frames -= frames_in_video
+            cap.release()
 
-        return processed_frames
+        self.current_video = None
 
-    def _load_next_video(self) -> None:
-        if self.current_video is not None:
-            self.current_video.release()
+    def read(self) -> torch.Tensor | None:
+        """Read one frame from the video. Returns None if all frames have been
+        read.
 
-        # Check if we've processed all folders
-        if self.current_folder_index >= len(self.folders):
-            raise StopIteration("All videos have been processed")
+        Returns:
+            torch.Tensor | None: The read frame as a torch.Tensor, or None if no more frames.
 
-        # Move to the next folder if we've processed all videos in the current folder
-        if self.current_video_index >= len(self.video_files[self.current_folder_index]):
-            self.current_folder_index += 1
-            self.current_video_index = 0
-            return self._load_next_video()
-
-        # Load the next video
-        video_path = self.video_files[self.current_folder_index][self.current_video_index]
-        self.current_video = cv2.VideoCapture(str(video_path))
-
-        # Set the starting frame
-        start_frame = self.start_frame_per_videos[self.current_folder_index]
-        self.current_video.set(cv2.CAP_PROP_POS_FRAMES, start_frame)
-        self.current_frame_index = start_frame
-
-    def __call__(self) -> torch.Tensor:
-        if self.current_video is None:
-            raise StopIteration("All videos have been processed")
+        Raises:
+            RuntimeError: If there's an error reading the video file.
+        """
+        if self.is_finished or self.current_video is None:
+            return None
 
         ret, frame = self.current_video.read()
         if not ret:
-            warnings.warn(
-                f"Failed to read a frame from {self.video_files[self.current_folder_index][self.current_video_index]}, "
-                "loading next video file.",
-                RuntimeWarning,
-            )
+            frames_in_current_video = int(self.current_video.get(cv2.CAP_PROP_FRAME_COUNT))
+            current_frame_in_video = int(self.current_video.get(cv2.CAP_PROP_POS_FRAMES))
+
+            if current_frame_in_video < frames_in_current_video:
+                self.current_video.release()
+                raise RuntimeError(
+                    f"Error reading frame {current_frame_in_video} from video file {self.video_files[self.current_video_index]}"
+                )
+
+            self.current_video.release()
             self.current_video_index += 1
-            self._load_next_video()
-            return self.__call__()
+            if self.current_video_index < len(self.video_files):
+                self.current_video = self._open_video_file(self.video_files[self.current_video_index])
+                return self.read()
+            else:
+                self.current_video = None
+                return None
 
-        self.current_frame_index += 1
-
-        # Check if we've reached the frame limit for the current folder
-        frames_processed = self.current_frame_index - self.start_frame_per_videos[self.current_folder_index]
-        if frames_processed >= self.video_frames_per_videos[self.current_folder_index]:
-            self.current_video_index += 1
-            self._load_next_video()
-            return self.__call__()
-
-        # Convert BGR to RGB
+        self.current_frame += 1
         frame_rgb = cv2.cvtColor(frame, cv2.COLOR_BGR2RGB)
+        return torch.from_numpy(frame_rgb).permute(2, 0, 1).float() / 255.0
 
-        # Convert to torch tensor and normalize
-        tensor = torch.from_numpy(frame_rgb).float().permute(2, 0, 1) / 255.0
+    @property
+    def is_finished(self) -> bool:
+        """Check if all frames have been read."""
+        return (self.current_frame - self.start_frame) >= self.max_frames
 
-        # Resize
-        tensor = v2.functional.resize(tensor, self.image_size)
+    def __iter__(self) -> Iterator[torch.Tensor]:
+        return self
 
-        return tensor
+    def __next__(self) -> torch.Tensor:
+        frame = self.read()
+        if frame is None:
+            raise StopIteration
+        return frame

--- a/tests/interactions/environments/test_video_folders_image_observation_generator.py
+++ b/tests/interactions/environments/test_video_folders_image_observation_generator.py
@@ -5,29 +5,31 @@ import torch
 
 from ami.interactions.environments.video_folders_image_observation_generator import (
     FolderAsVideo,
+    VideoFoldersImageObservationGenerator,
 )
 
 
+@pytest.fixture
+def video_folder(tmp_path):
+    folder = tmp_path / "test_videos"
+    folder.mkdir()
+    create_test_video(folder / "video1.mp4", num_frames=10)
+    create_test_video(folder / "video2.mp4", num_frames=10)
+    return folder
+
+
+def create_test_video(file_path, num_frames=10, width=64, height=64):
+    fourcc = cv2.VideoWriter.fourcc(*"mp4v")
+    out = cv2.VideoWriter(str(file_path), fourcc, 30, (width, height))
+
+    for i in range(num_frames):
+        frame = np.full((height, width, 3), 255, dtype=np.uint8)  # Each frame has a different color
+        out.write(frame)
+
+    out.release()
+
+
 class TestFolderAsVideo:
-    @pytest.fixture
-    def video_folder(self, tmp_path):
-        folder = tmp_path / "test_videos"
-        folder.mkdir()
-        self.create_test_video(folder / "video1.mp4", num_frames=10)
-        self.create_test_video(folder / "video2.mp4", num_frames=10)
-        return folder
-
-    @staticmethod
-    def create_test_video(file_path, num_frames=10, width=64, height=64):
-        fourcc = cv2.VideoWriter.fourcc(*"mp4v")
-        out = cv2.VideoWriter(str(file_path), fourcc, 30, (width, height))
-
-        for _ in range(num_frames):
-            frame = np.full((height, width, 3), 255, dtype=np.uint8)  # Each frame has a different color
-            out.write(frame)
-
-        out.release()
-
     def test_basic_functionality(self, video_folder):
         folder_video = FolderAsVideo(video_folder)
         assert folder_video.total_frames == 20
@@ -72,3 +74,112 @@ class TestFolderAsVideo:
         assert folder_video.is_finished
         with pytest.raises(RuntimeError):
             folder_video.read()
+
+
+class TestVideoFoldersImageObservationGenerator:
+    def test_basic_functionality(self, video_folder):
+        generator = VideoFoldersImageObservationGenerator(folder_paths=[video_folder], image_size=(32, 32))
+
+        frames = []
+        for _ in range(20):
+            frames.append(generator())
+
+        assert len(frames) == 20
+        for frame in frames:
+            assert isinstance(frame, torch.Tensor)
+            assert frame.shape == (3, 32, 32)
+
+    def test_multiple_folders(self, tmp_path):
+        folder1 = tmp_path / "folder1"
+        folder2 = tmp_path / "folder2"
+        folder1.mkdir()
+        folder2.mkdir()
+        create_test_video(folder1 / "video1.mp4", num_frames=5)
+        create_test_video(folder2 / "video2.mp4", num_frames=5)
+
+        generator = VideoFoldersImageObservationGenerator(folder_paths=[folder1, folder2], image_size=(32, 32))
+
+        frames = []
+        for _ in range(10):
+            frames.append(generator())
+
+        assert len(frames) == 10
+
+    def test_start_frames(self, video_folder):
+        generator = VideoFoldersImageObservationGenerator(
+            folder_paths=[video_folder], image_size=(32, 32), folder_start_frames=5
+        )
+
+        frames = list(generator)
+        assert len(frames) == 15
+
+    def test_frame_limits(self, video_folder):
+        generator = VideoFoldersImageObservationGenerator(
+            folder_paths=[video_folder], image_size=(32, 32), folder_frame_limits=15
+        )
+
+        frames = list(generator)
+        assert len(frames) == 15
+
+    def test_start_frames_and_frame_limits(self, video_folder):
+        generator = VideoFoldersImageObservationGenerator(
+            folder_paths=[video_folder], image_size=(32, 32), folder_start_frames=5, folder_frame_limits=10
+        )
+
+        frames = list(generator)
+        assert len(frames) == 10
+
+    def test_different_settings_for_multiple_folders(self, tmp_path):
+        folder1 = tmp_path / "folder1"
+        folder2 = tmp_path / "folder2"
+        folder1.mkdir()
+        folder2.mkdir()
+        create_test_video(folder1 / "video1.mp4", num_frames=10)
+        create_test_video(folder2 / "video2.mp4", num_frames=10)
+
+        generator = VideoFoldersImageObservationGenerator(
+            folder_paths=[folder1, folder2],
+            image_size=(32, 32),
+            folder_start_frames=[0, 5],
+            folder_frame_limits=[5, None],
+        )
+
+        frames = list(iter(generator))
+        assert len(frames) == 10  # 5 from first folder, 5 from second folder
+
+    def test_stop_iteration(self, video_folder):
+        generator = VideoFoldersImageObservationGenerator(folder_paths=[video_folder], image_size=(32, 32))
+
+        for _ in range(20):
+            generator()
+
+        with pytest.raises(StopIteration):
+            generator()
+
+    def test_image_resizing(self, video_folder):
+        generator = VideoFoldersImageObservationGenerator(folder_paths=[video_folder], image_size=(128, 128))
+
+        frame = generator()
+        assert frame.shape == (3, 128, 128)
+
+    def test_invalid_input(self, video_folder):
+        with pytest.raises(ValueError):
+            VideoFoldersImageObservationGenerator(
+                folder_paths=[video_folder],
+                image_size=(32, 32),
+                folder_start_frames=[0, 5],  # This should raise an error as there's only one folder
+            )
+
+        with pytest.raises(ValueError):
+            VideoFoldersImageObservationGenerator(
+                folder_paths=[video_folder],
+                image_size=(32, 32),
+                folder_frame_limits=[10, 20],  # This should raise an error as there's only one folder
+            )
+
+    def test_frame_values(self, video_folder):
+        generator = VideoFoldersImageObservationGenerator(folder_paths=[video_folder], image_size=(64, 64))
+
+        for _ in range(20):
+            frame = generator()
+            assert torch.allclose(frame, torch.full_like(frame, 1.0), atol=1e-1)

--- a/tests/interactions/environments/test_video_folders_image_observation_generator.py
+++ b/tests/interactions/environments/test_video_folders_image_observation_generator.py
@@ -19,7 +19,7 @@ class TestFolderAsVideo:
 
     @staticmethod
     def create_test_video(file_path, num_frames=10, width=64, height=64):
-        fourcc = cv2.VideoWriter_fourcc(*"mp4v")
+        fourcc = cv2.VideoWriter.fourcc(*"mp4v")
         out = cv2.VideoWriter(str(file_path), fourcc, 30, (width, height))
 
         for _ in range(num_frames):
@@ -63,3 +63,12 @@ class TestFolderAsVideo:
 
         with pytest.raises(ValueError):
             FolderAsVideo(video_folder, max_frames=999999)
+
+    def test_overread_error(self, video_folder):
+        folder_video = FolderAsVideo(video_folder, start_frame=0, max_frames=5)
+        for _ in range(5):
+            folder_video.read()
+
+        assert folder_video.is_finished
+        with pytest.raises(RuntimeError):
+            folder_video.read()

--- a/tests/interactions/environments/test_video_folders_image_observation_generator.py
+++ b/tests/interactions/environments/test_video_folders_image_observation_generator.py
@@ -144,7 +144,7 @@ class TestVideoFoldersImageObservationGenerator:
             folder_frame_limits=[5, None],
         )
 
-        frames = list(iter(generator))
+        frames = list(generator)
         assert len(frames) == 10  # 5 from first folder, 5 from second folder
 
     def test_stop_iteration(self, video_folder):


### PR DESCRIPTION
## 概要

#88 の要件を PR #87 は満たすことができていなかったため、作り直した。
FolderAsVideoクラスの追加で、Folderに多数存在するファイルを一つの連結したVideoとして扱えるようにした。
VideoFoldersImageObservationGeneratorはそのクラスを利用した実装とした。

## 変更内容

<!-- ビューの変更がある場合はスクショによる比較などがあるとわかりやすい -->

## 影響範囲

<!-- この関数を変更したのでこの機能にも影響がある、など -->

## Submit前の確認項目

<!-- PRをSubmitする前に確認する項目 -->

- [x] タイトルは一目でわかるようにし、説明文は PR を簡潔に説明するようにしましたか?
- [x] あなたの PR が、異なる変更を束ねたものではなく、ひとつのことだけを行うものであることを確認しましたか?
- [x] この PR で導入されたすべての変更点をリストアップしましたか?
- [x] PR を`make run`コマンドでローカルでテストしましたか?

## 補足

<!-- レビューをする際に見てほしい点、ローカル環境で試す際の注意点、など -->
