### PR TITLE
モデルを推論スレッドのみで使用する機能を実装

### DIFF
--- a/ami/models/utils.py
+++ b/ami/models/utils.py
@@ -94,6 +94,22 @@ class ModelWrappersDict(UserDict[str, ModelWrapper[nn.Module]], SaveAndLoadState
     def __delitem__(self, key: str) -> None:
         raise RuntimeError(f"Deleting item is prohibited! Key:{key!r}")
 
+    def remove_inference_thread_only_models(self) -> list[str]:
+        """Removes the model that is used for inference thread only from
+        ModelWrappersDict.
+
+        Returns:
+            list[str]: Removed model names.
+        """
+        self.inference_wrappers_dict  # Create inference wrappers dict when not created.
+
+        removed_names = []
+        for name, wrapper in list(self.data.items()):
+            if wrapper.inference_thread_only:
+                del self.data[name]
+                removed_names.append(name)
+        return removed_names
+
 
 def count_model_parameters(model: nn.Module) -> tuple[int, int, int]:
     """Counts the number of model parameters.

--- a/ami/threads/training_thread.py
+++ b/ami/threads/training_thread.py
@@ -29,6 +29,10 @@ class TrainingThread(BackgroundThread):
 
         self.share_object(SharedObjectNames.INFERENCE_MODELS, models.inference_wrappers_dict)
 
+        removed_names = self.models.remove_inference_thread_only_models()
+        if len(removed_names) != 0:
+            self.logger.debug(f"The inference thread only models are removed from training thread: {removed_names!r}")
+
     def on_shared_objects_pool_attached(self) -> None:
         super().on_shared_objects_pool_attached()
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -45,6 +45,7 @@ def model_wrappers_dict(gpu_device: torch.device | None) -> ModelWrappersDict:
             "model2": ModelWrapper(ModelMultiplyP(), "cpu", True),
             "model_device": ModelWrapper(ModelMultiplyP(), device, True),
             "model_no_inference": ModelWrapper(ModelMultiplyP(), "cpu", False),
+            "model_inference_thread_only": ModelWrapper(ModelMultiplyP(), "cpu", True, inference_thread_only=True),
         }
     )
     d.send_to_default_device()

--- a/tests/models/test_model_wrapper.py
+++ b/tests/models/test_model_wrapper.py
@@ -88,3 +88,20 @@ class TestWrappers:
         mw = ModelWrapper(ModelMultiplyP(), "cpu", True, parameter_file=param_file)
 
         assert torch.equal(mw.model.p, m.p)
+
+    def test_inference_thread_only(self):
+        m = ModelWrapper(ModelMultiplyP(), has_inference=True, inference_thread_only=True)
+        iw = m.inference_wrapper
+
+        assert m.inference_thread_only
+        assert iw._wrapper is m
+
+        # default false.
+        m = ModelWrapper(ModelMultiplyP(), has_inference=True)
+        iw = m.inference_wrapper
+        assert not m.inference_thread_only
+        assert iw._wrapper is not m
+
+        # test consistency between `has_inference` and `inference_thread_only`
+        with pytest.raises(ValueError):
+            ModelWrapper(ModelMultiplyP(), has_inference=False, inference_thread_only=True)

--- a/tests/models/test_utils.py
+++ b/tests/models/test_utils.py
@@ -83,6 +83,16 @@ class TestWrappersDict:
 
         mwd.load_state(models_path)
 
+    def test_remove_inference_thread_only_models(self):
+        mwd = ModelWrappersDict(
+            a=ModelWrapper(ModelMultiplyP(), "cpu", True),
+            b=ModelWrapper(ModelMultiplyP(), "cpu", True, inference_thread_only=True),
+        )
+        removed_names = mwd.remove_inference_thread_only_models()
+        assert removed_names == ["b"]
+        assert "b" not in mwd
+        assert "b" in mwd.inference_wrappers_dict
+
 
 class DummyModel(torch.nn.Module):
     def __init__(self, *args, **kwargs) -> None:

--- a/tests/threads/test_training_thread.py
+++ b/tests/threads/test_training_thread.py
@@ -7,6 +7,12 @@ from ami.threads.training_thread import DataUsersDict, ModelWrappersDict, Traine
 
 
 class TestTrainingThread:
+    def test_removing_inference_thread_only_models(self, thread_objects):
+        inference_thread: InferenceThread = thread_objects[1]
+        training_thread: TrainingThread = thread_objects[2]
+        assert "model_inference_thread_only" not in training_thread.models
+        assert "model_inference_thread_only" in inference_thread.inference_models
+
     def test_save_and_load_state(self, thread_objects, mocker: MockerFixture, tmp_path: Path) -> TrainingThread:
 
         training_thread: TrainingThread = thread_objects[2]


### PR DESCRIPTION
## 概要

#110 に関連して、AMI System上でモデルをInferenceThread上のみで使用する機能を実装した。

## 変更内容

<!-- ビューの変更がある場合はスクショによる比較などがあるとわかりやすい -->

## 影響範囲

<!-- この関数を変更したのでこの機能にも影響がある、など -->

## Submit前の確認項目

<!-- PRをSubmitする前に確認する項目 -->

- [x] タイトルは一目でわかるようにし、説明文は PR を簡潔に説明するようにしましたか?
- [x] あなたの PR が、異なる変更を束ねたものではなく、ひとつのことだけを行うものであることを確認しましたか?
- [x] この PR で導入されたすべての変更点をリストアップしましたか?
- [x] PR を`make run`コマンドでローカルでテストしましたか?

## 補足

<!-- レビューをする際に見てほしい点、ローカル環境で試す際の注意点、など -->
