### PR TITLE
SioConvだけを学習するexperiment configを追加

### DIFF
--- a/ami/interactions/io_wrappers/tensor_csv_recorder.py
+++ b/ami/interactions/io_wrappers/tensor_csv_recorder.py
@@ -145,24 +145,24 @@ class TensorCSVReader(Generic[ValueType]):
         converted_data = [self.value_converter(d) for d in selected_data]
         return torch.tensor(converted_data)
 
-    def __getstate__(self) -> dict[str, Any]:
-        """Prepare the object for pickling."""
-        state = self.__dict__.copy()
-        state["_reader_line_num"] = self.csv_reader.line_num
-        del state["csv_file"]
-        del state["csv_reader"]
-        return state
+    # def __getstate__(self) -> dict[str, Any]:
+    #     """Prepare the object for pickling."""
+    #     state = self.__dict__.copy()
+    #     state["_reader_line_num"] = self.csv_reader.line_num
+    #     del state["csv_file"]
+    #     del state["csv_reader"]
+    #     return state
 
-    def __setstate__(self, state: dict[str, Any]) -> None:
-        """Restore the object from its pickled state."""
-        reader_line_num = state.pop("_reader_line_num")
-        self.__dict__.update(state)
-        csv_file = open(self.file_path)
-        csv_reader = csv.reader(csv_file)
-        for _ in range(reader_line_num):
-            next(csv_reader)
-        self.csv_file = csv_file
-        self.csv_reader = csv_reader
+    # def __setstate__(self, state: dict[str, Any]) -> None:
+    #     """Restore the object from its pickled state."""
+    #     reader_line_num = state.pop("_reader_line_num")
+    #     self.__dict__.update(state)
+    #     csv_file = open(self.file_path)
+    #     csv_reader = csv.reader(csv_file)
+    #     for _ in range(reader_line_num):
+    #         next(csv_reader)
+    #     self.csv_file = csv_file
+    #     self.csv_reader = csv_reader
 
     def __del__(self) -> None:
         if hasattr(self, "csv_file"):

--- a/ami/interactions/io_wrappers/tensor_csv_recorder.py
+++ b/ami/interactions/io_wrappers/tensor_csv_recorder.py
@@ -145,5 +145,25 @@ class TensorCSVReader(Generic[ValueType]):
         converted_data = [self.value_converter(d) for d in selected_data]
         return torch.tensor(converted_data)
 
+    def __getstate__(self) -> dict[str, Any]:
+        """Prepare the object for pickling."""
+        state = self.__dict__.copy()
+        state["_reader_line_num"] = self.csv_reader.line_num
+        del state["csv_file"]
+        del state["csv_reader"]
+        return state
+
+    def __setstate__(self, state: dict[str, Any]) -> None:
+        """Restore the object from its pickled state."""
+        reader_line_num = state.pop("_reader_line_num")
+        self.__dict__.update(state)
+        csv_file = open(self.file_path)
+        csv_reader = csv.reader(csv_file)
+        for _ in range(reader_line_num):
+            next(csv_reader)
+        self.csv_file = csv_file
+        self.csv_reader = csv_reader
+
     def __del__(self) -> None:
-        self.csv_file.close()
+        if hasattr(self, "csv_file"):
+            self.csv_file.close()

--- a/ami/models/components/deterministic.py
+++ b/ami/models/components/deterministic.py
@@ -30,7 +30,10 @@ class Deterministic(Distribution):
 
         The entropy of a deterministic distribution is always zero.
         """
-        return torch.zeros_like(self.data)
+        ent = torch.zeros_like(self.data)
+        if not torch.is_floating_point(ent):
+            ent = ent.float()
+        return ent
 
     def log_prob(self, value: Tensor) -> Tensor:
         """Computes the log probability of the given value.
@@ -40,5 +43,7 @@ class Deterministic(Distribution):
         negative infinity (probability 0) otherwise.
         """
         prob = torch.zeros_like(value)
+        if not torch.is_floating_point(prob):
+            prob = prob.float()
         prob[self.data != value] = -torch.inf
         return prob

--- a/configs/data_collectors/dynamics.yaml
+++ b/configs/data_collectors/dynamics.yaml
@@ -1,0 +1,8 @@
+forward_dynamics_trajectory:
+  _target_: ami.data.buffers.causal_data_buffer.CausalDataBuffer.reconstructable_init
+  max_len: 2048
+  key_list:
+    - "observation"
+    - "hidden"
+    - "action"
+    - "reward"

--- a/configs/experiment/learn_only_sioconv.yaml
+++ b/configs/experiment/learn_only_sioconv.yaml
@@ -28,6 +28,7 @@ interaction:
 
 models:
   i_jepa_target_encoder:
+    inference_thread_only: True
     parameter_file: null # 学習済モデルをセットする。
     model:
       patch_size: 12
@@ -55,9 +56,15 @@ models:
 data_collectors:
   forward_dynamics_trajectory:
     max_len: ${python.eval:"20 * ${trainers.forward_dynamics.partial_dataloader.batch_size}"}
+    key_list:
+      - "embed_observation" # 学習済Observation Encoderの出力を使う
+      - "hidden"
+      - "action"
+      - "reward"
 
 trainers:
   forward_dynamics:
+    observation_encoder_name: null # embed observationを直接使う
     max_epochs: 1
     partial_dataloader:
       batch_size: ${python.eval:"256 + 1"} # 学習する系列長. +1することでバッチから1ステップ先の予測対象データを抜き出す。

--- a/configs/experiment/learn_only_sioconv.yaml
+++ b/configs/experiment/learn_only_sioconv.yaml
@@ -60,7 +60,7 @@ trainers:
   forward_dynamics:
     max_epochs: 1
     partial_dataloader:
-      batch_size: ${python.eval:"256 + 1"}
+      batch_size: ${python.eval:"256 + 1"} # 学習する系列長. +1することでバッチから1ステップ先の予測対象データを抜き出す。
     minimum_new_data_count: 128
 
 task_name: "learn_only_sioconv_large"

--- a/configs/experiment/learn_only_sioconv.yaml
+++ b/configs/experiment/learn_only_sioconv.yaml
@@ -1,0 +1,66 @@
+# @package _global_
+
+defaults:
+  - override /data_collectors: dynamics
+  - override /interaction/environment: video_folders
+  - override /interaction/agent: curiosity_image_multi_step_imagination
+  - override /models: learn_only_sioconv_large
+  - override /trainers: forward_dynamics_with_action_reward
+
+shared:
+  image_height: 144
+  image_width: 144
+  frame_limit: ${python.eval:"int(10 * ${cvt_time_str:4h})"} # 10FPS, 4時間分. 6サンプルで24時間分
+
+interaction:
+  agent:
+    max_imagination_steps: 50 # 5 sec
+  environment:
+    observation_generator:
+      folder_frame_limits: ${shared.frame_limit}
+      folder_paths:
+        - ${paths.data_dir}/random_observation_action_log/2024-08-26_12-55-45/io/video_recordings
+        - ${paths.data_dir}/random_observation_action_log/2024-08-26_13-00-14/io/video_recordings
+        - ${paths.data_dir}/random_observation_action_log/2024-08-26_13-04-15/io/video_recordings
+        - ${paths.data_dir}/random_observation_action_log/2024-08-26_13-08-31/io/video_recordings
+        - ${paths.data_dir}/random_observation_action_log/2024-08-27_09-28-27/io/video_recordings
+        - ${paths.data_dir}/random_observation_action_log/2024-08-27_09-31-50/io/video_recordings
+
+models:
+  i_jepa_target_encoder:
+    parameter_file: null # 学習済モデルをセットする。
+    model:
+      patch_size: 12
+      embed_dim: 648
+      out_dim: 32
+      depth: 12
+      num_heads: 9
+  policy:
+    model:
+      file_max_rows: ${shared.frame_limit}
+      column_headers:
+        - "MoveVertical"
+        - "MoveHorizontal"
+        - "LookHorizontal"
+        - "Jump"
+        - "Run"
+      file_paths:
+        - ${paths.data_dir}/random_observation_action_log/2024-08-26_12-55-45/io/action_log.csv
+        - ${paths.data_dir}/random_observation_action_log/2024-08-26_13-00-14/io/action_log.csv
+        - ${paths.data_dir}/random_observation_action_log/2024-08-26_13-04-15/io/action_log.csv
+        - ${paths.data_dir}/random_observation_action_log/2024-08-26_13-08-31/io/action_log.csv
+        - ${paths.data_dir}/random_observation_action_log/2024-08-27_09-28-27/io/action_log.csv
+        - ${paths.data_dir}/random_observation_action_log/2024-08-27_09-31-50/io/action_log.csv
+
+data_collectors:
+  forward_dynamics_trajectory:
+    max_len: ${python.eval:"20 * ${trainers.forward_dynamics.partial_dataloader.batch_size}"}
+
+trainers:
+  forward_dynamics:
+    max_epochs: 1
+    partial_dataloader:
+      batch_size: ${python.eval:"256 + 1"}
+    minimum_new_data_count: 128
+
+task_name: "learn_only_sioconv_large"

--- a/configs/models/learn_only_sioconv.yaml
+++ b/configs/models/learn_only_sioconv.yaml
@@ -1,0 +1,127 @@
+image_encoder: i_jepa_target_encoder # Alias for ImageEncodingAgent.
+
+i_jepa_target_encoder:
+  _target_: ami.models.model_wrapper.ModelWrapper
+  default_device: ${devices.0}
+  has_inference: True
+  inference_thread_only: True
+  parameter_file: ???
+  inference_forward:
+    _target_: hydra.utils.get_method
+    path: ami.models.bool_mask_i_jepa.i_jepa_encoder_infer
+  model:
+    _target_: ami.models.bool_mask_i_jepa.BoolMaskIJEPAEncoder
+    img_size:
+      - ${shared.image_height} # Assuming 84
+      - ${shared.image_width} # Assuming 84
+    in_channels: ${shared.image_channels} # Assume 3
+    patch_size: 12
+    embed_dim: 512
+    out_dim: 32 # 1 / 13.5
+    depth: 4
+    num_heads: 4
+    mlp_ratio: 4.0
+
+forward_dynamics:
+  _target_: ami.models.model_wrapper.ModelWrapper
+  default_device: ${devices.0}
+  has_inference: True
+  model:
+    _target_: ami.models.forward_dynamics.ForwardDynamcisWithActionReward
+    observation_flatten:
+      _target_: ami.models.components.stacked_features.LerpStackedFeatures
+      dim_in: ${models.i_jepa_target_encoder.model.out_dim}
+      dim_out: 512
+      num_stack: ${python.eval:"12 * 12"} # assuming image size is 144x144, patch size is 12x12.
+    action_flatten:
+      _target_: ami.models.components.multi_embeddings.MultiEmbeddings
+      choices_per_category:
+        _target_: hydra.utils.get_object
+        path: ami.interactions.environments.actuators.vrchat_osc_discrete_actuator.ACTION_CHOICES_PER_CATEGORY
+      embedding_dim: 8
+      do_flatten: True
+    obs_action_projection:
+      _target_: torch.nn.Linear
+      # action_embedding_dim * num_action_choices + obs_embedding_dim
+      in_features: ${python.eval:"${..action_flatten.embedding_dim} * 5 + ${..observation_flatten.dim_out}"}
+      out_features: ${..core_model.dim}
+    core_model:
+      _target_: ami.models.components.sioconv.SioConv
+      depth: 8
+      dim: 512
+      num_head: 8
+      dim_ff_hidden: 512
+      chunk_size: 512
+      dropout: 0.1
+    obs_hat_dist_head:
+      _target_: torch.nn.Sequential
+      _args_:
+        - _target_: ami.models.components.stacked_features.ToStackedFeatures
+          dim_in: ${....core_model.dim}
+          dim_out: ${models.i_jepa_target_encoder.model.out_dim}
+          num_stack: ${....observation_flatten.num_stack}
+        - _target_: ami.models.components.mixture_desity_network.NormalMixtureDensityNetwork
+          in_features: ${..0.dim_out}
+          out_features: ${models.i_jepa_target_encoder.model.out_dim}
+          num_components: 8
+    action_hat_dist_head:
+      _target_: ami.models.components.discrete_policy_head.DiscretePolicyHead
+      dim_in: ${..core_model.dim}
+      action_choices_per_category:
+        _target_: hydra.utils.get_object
+        path: ami.interactions.environments.actuators.vrchat_osc_discrete_actuator.ACTION_CHOICES_PER_CATEGORY
+    reward_hat_dist_head:
+      _target_: ami.models.components.mixture_desity_network.NormalMixtureDensityNetwork
+      in_features: ${..core_model.dim}
+      out_features: 1
+      num_components: 8
+      squeeze_feature_dim: True
+
+policy:
+  _target_: ami.models.model_wrapper.ModelWrapper
+  default_device: ${devices.0}
+  has_inference: True
+  inference_thread_only: True
+  model:
+    _target_: ami.models.csv_files_policy.CSVFilesPolicy
+    file_paths: ???
+    column_headers: ???
+    dtype: ${torch.dtype:long}
+    device: ${devices.0}
+    observation_ndim: 2
+
+value:
+  _target_: ami.models.model_wrapper.ModelWrapper
+  default_device: ${devices.0}
+  has_inference: True
+  inference_thread_only: True
+  model:
+    _target_: ami.models.policy_or_value_network.PolicyOrValueNetwork
+    observation_projection:
+      _target_: ami.models.components.stacked_features.LerpStackedFeatures
+      dim_in: ${models.i_jepa_target_encoder.model.out_dim}
+      dim_out: 1
+      num_stack: ${python.eval:"12 * 12"} # assuming image size is 144x144, patch size is 12x12.
+    forward_dynamics_hidden_projection:
+      _target_: ami.models.policy_value_common_net.LerpStackedHidden
+      dim: ${models.forward_dynamics.model.core_model.dim}
+      depth: ${models.forward_dynamics.model.core_model.depth}
+      num_head: ${models.forward_dynamics.model.core_model.num_head}
+    observation_hidden_projection:
+      _target_: ami.models.policy_value_common_net.ConcatFlattenedObservationAndLerpedHidden
+      dim_obs: ${..observation_projection.dim_out}
+      dim_hidden: ${models.forward_dynamics.model.core_model.dim}
+      dim_out: 1
+    core_model:
+      _target_: ami.models.components.resnet.ResNetFF
+      dim: ${..observation_hidden_projection.dim_out}
+      dim_hidden: 1
+      depth: 1
+    dist_head:
+      _target_: ami.models.components.fully_connected_fixed_std_normal.FullyConnectedFixedStdNormal
+      dim_in: ${..observation_hidden_projection.dim_out}
+      dim_out: 1
+      squeeze_feature_dim: True
+      normal_cls:
+        _target_: hydra.utils.get_class
+        path: ami.models.components.fully_connected_fixed_std_normal.DeterministicNormal

--- a/configs/models/learn_only_sioconv.yaml
+++ b/configs/models/learn_only_sioconv.yaml
@@ -4,7 +4,6 @@ i_jepa_target_encoder:
   _target_: ami.models.model_wrapper.ModelWrapper
   default_device: ${devices.0}
   has_inference: True
-  inference_thread_only: True
   parameter_file: ???
   inference_forward:
     _target_: hydra.utils.get_method

--- a/configs/models/learn_only_sioconv_large.yaml
+++ b/configs/models/learn_only_sioconv_large.yaml
@@ -1,0 +1,11 @@
+defaults:
+  - learn_only_sioconv
+
+forward_dynamics:
+  model:
+    observation_flatten:
+      dim_out: 2048
+    core_model:
+      depth: 12
+      dim: 2048
+      dim_ff_hidden: ${python.eval:"${.dim} * 2"}

--- a/configs/trainers/forward_dynamics_with_action_reward.yaml
+++ b/configs/trainers/forward_dynamics_with_action_reward.yaml
@@ -1,0 +1,2 @@
+defaults:
+  - forward_dynamics: with_action_reward

--- a/tests/interactions/io_wrappers/test_tensor_csv_recorder.py
+++ b/tests/interactions/io_wrappers/test_tensor_csv_recorder.py
@@ -1,5 +1,4 @@
 import os
-import pickle
 
 import pytest
 import torch
@@ -8,6 +7,8 @@ from ami.interactions.io_wrappers.tensor_csv_recorder import (
     TensorCSVReader,
     TensorCSVRecorder,
 )
+
+# import pickle
 
 
 class TestTensorCSVRecorder:
@@ -121,11 +122,11 @@ class TestTensorCSVReader:
                 file_path=str(empty_csv), column_headers=["value1", "value2", "value3"], value_converter=float
             )
 
-    def test_pickling(self, csv_reader: TensorCSVReader):
-        assert torch.equal(csv_reader.read(), torch.tensor([1.0, 2.0, 3.0]))
-        assert csv_reader.current_row == 1
+    # def test_pickling(self, csv_reader: TensorCSVReader):
+    #     assert torch.equal(csv_reader.read(), torch.tensor([1.0, 2.0, 3.0]))
+    #     assert csv_reader.current_row == 1
 
-        csv_reader = pickle.loads(pickle.dumps(csv_reader))
-        assert csv_reader.current_row == 1
-        assert torch.equal(csv_reader.read(), torch.tensor([4.0, 5.0, 6.0]))
-        assert csv_reader.current_row == 2
+    #     csv_reader = pickle.loads(pickle.dumps(csv_reader))
+    #     assert csv_reader.current_row == 1
+    #     assert torch.equal(csv_reader.read(), torch.tensor([4.0, 5.0, 6.0]))
+    #     assert csv_reader.current_row == 2

--- a/tests/interactions/io_wrappers/test_tensor_csv_recorder.py
+++ b/tests/interactions/io_wrappers/test_tensor_csv_recorder.py
@@ -1,4 +1,5 @@
 import os
+import pickle
 
 import pytest
 import torch
@@ -119,3 +120,12 @@ class TestTensorCSVReader:
             TensorCSVReader(
                 file_path=str(empty_csv), column_headers=["value1", "value2", "value3"], value_converter=float
             )
+
+    def test_pickling(self, csv_reader: TensorCSVReader):
+        assert torch.equal(csv_reader.read(), torch.tensor([1.0, 2.0, 3.0]))
+        assert csv_reader.current_row == 1
+
+        csv_reader = pickle.loads(pickle.dumps(csv_reader))
+        assert csv_reader.current_row == 1
+        assert torch.equal(csv_reader.read(), torch.tensor([4.0, 5.0, 6.0]))
+        assert csv_reader.current_row == 2

--- a/tests/test_configs.py
+++ b/tests/test_configs.py
@@ -34,7 +34,7 @@ IGNORE_EXPERIMENT_CONFIGS = {
 DATA_DIR = PROJECT_ROOT / "data"
 if not (DATA_DIR / "random_observation_action_log").exists():
     IGNORE_EXPERIMENT_CONFIGS.add("bool_mask_i_jepa_with_videos.yaml")
-    IGNORE_EXPERIMENT_CONFIGS.add("learn_only_sioconve.yaml")
+    IGNORE_EXPERIMENT_CONFIGS.add("learn_only_sioconv.yaml")
 
 EXPERIMENT_CONFIG_OVERRIDES = [
     [f"experiment={file.name.rsplit('.', 1)[0]}"]

--- a/tests/test_configs.py
+++ b/tests/test_configs.py
@@ -34,6 +34,7 @@ IGNORE_EXPERIMENT_CONFIGS = {
 DATA_DIR = PROJECT_ROOT / "data"
 if not (DATA_DIR / "random_observation_action_log").exists():
     IGNORE_EXPERIMENT_CONFIGS.add("bool_mask_i_jepa_with_videos.yaml")
+    IGNORE_EXPERIMENT_CONFIGS.add("learn_only_sioconve.yaml")
 
 EXPERIMENT_CONFIG_OVERRIDES = [
     [f"experiment={file.name.rsplit('.', 1)[0]}"]


### PR DESCRIPTION
## 概要

#110 SioConvだけを学習するexperiment configファイルクラスを実装しました。
Videoおよびaction のcsvファイルを用いて学習します。
観測エンコーダは学習済のものを使いますので、I-JEPAの実験が終了した時点での最良モデルを`parameter_file`に設定します。

テスト時にいくつかエラーが出ており、特になぜか CSVFilesPolicyがシリアライズ化されるという現象が発生し、それを解決するためのコードを記述しました。ただ、何かおかしいなと思ってコメントアウトしたら問題が再発生しなくなっていたため、謎です。


## 変更内容

<!-- ビューの変更がある場合はスクショによる比較などがあるとわかりやすい -->

## 影響範囲

<!-- この関数を変更したのでこの機能にも影響がある、など -->

## Submit前の確認項目

<!-- PRをSubmitする前に確認する項目 -->

- [x] タイトルは一目でわかるようにし、説明文は PR を簡潔に説明するようにしましたか?
- [x] あなたの PR が、異なる変更を束ねたものではなく、ひとつのことだけを行うものであることを確認しましたか?
- [x] この PR で導入されたすべての変更点をリストアップしましたか?
- [x] PR を`make run`コマンドでローカルでテストしましたか?

## 補足

<!-- レビューをする際に見てほしい点、ローカル環境で試す際の注意点、など -->
