### PR TITLE
想像上の軌道の再構成画像のログ機能を追加

### DIFF
--- a/ami/interactions/agents/multi_step_imagination_curiosity_agent.py
+++ b/ami/interactions/agents/multi_step_imagination_curiosity_agent.py
@@ -8,6 +8,8 @@ import numpy.typing as npt
 import seaborn
 import torch
 import torch.nn as nn
+import torchvision
+import torchvision.transforms.v2.functional
 from torch import Tensor
 from torch.distributions import Distribution
 from typing_extensions import override
@@ -36,6 +38,10 @@ class MultiStepImaginationCuriosityImageAgent(BaseAgent[Tensor, Tensor]):
         log_reward_imaginations_every_n_steps: int = 1,
         log_reward_imaginations_max_history_size: int = 1,
         log_reward_imaginations_append_interval: int = 1,
+        # 再構成画像の可視化ログについて
+        log_reconstruction_imaginations_every_n_steps: int = 1,
+        log_reconstruction_imaginations_max_history_size: int = 1,
+        log_reconstruction_imaginations_append_interval: int = 1,
     ) -> None:
         """Constructs Agent.
 
@@ -63,6 +69,16 @@ class MultiStepImaginationCuriosityImageAgent(BaseAgent[Tensor, Tensor]):
         self.reward_imaginations_global_step_deque: deque[int] = deque(maxlen=log_reward_imaginations_max_history_size)
         self.log_reward_imaginations_append_interval = log_reward_imaginations_append_interval
 
+        # 観測の再構成画像ログについて
+        self.log_reconstruction_imaginations_every_n_steps = log_reconstruction_imaginations_every_n_steps
+        self.log_reconstruction_imaginations_append_interval = log_reconstruction_imaginations_append_interval
+        self.reconstruction_imaginations_deque: deque[Tensor] = deque(
+            maxlen=log_reconstruction_imaginations_max_history_size
+        )
+        self.reconstruction_imaginations_ground_truth_deque: deque[Tensor] = deque(
+            maxlen=log_reconstruction_imaginations_max_history_size
+        )
+
     @property
     def global_step(self) -> int:
         return self.logger.global_step
@@ -81,6 +97,10 @@ class MultiStepImaginationCuriosityImageAgent(BaseAgent[Tensor, Tensor]):
             policy_net: ThreadSafeInferenceWrapper[PolicyOrValueNetwork] = self.get_inference_model(ModelNames.POLICY)
             value_net: ThreadSafeInferenceWrapper[PolicyOrValueNetwork] = self.get_inference_model(ModelNames.VALUE)
             self.policy_value_net = PolicyValueCommonProxy(policy_net, value_net)
+
+        self.image_decoder: ThreadSafeInferenceWrapper[nn.Module] | None = None
+        if self.check_model_exists(ModelNames.IMAGE_DECODER):
+            self.image_decoder = self.get_inference_model(ModelNames.IMAGE_DECODER)
 
     # ------ Interaction Process ------
     exact_forward_dynamics_hidden_state: Tensor  # (depth, dim)
@@ -129,6 +149,23 @@ class MultiStepImaginationCuriosityImageAgent(BaseAgent[Tensor, Tensor]):
                 and len(self.reward_imaginations_deque) > 0
             ):
                 self.visualize_reward_imaginations()
+
+            # 長期的予測の再構成画像とそのGround Truthの格納
+            if (
+                self.image_decoder is not None
+                and self.predicted_embed_obs_imaginations.size(0) == self.max_imagination_steps
+                and self.global_step % self.log_reconstruction_imaginations_append_interval == 0
+            ):
+                self.reconstruction_imaginations_ground_truth_deque.append(observation.cpu())
+                reconstructions: Tensor = self.image_decoder(self.predicted_embed_obs_imaginations)
+                self.reconstruction_imaginations_deque.append(reconstructions.cpu())
+
+            # 長期予測の再構成画像の可視化
+            if (
+                self.global_step % self.log_reconstruction_imaginations_every_n_steps == 0
+                and len(self.reconstruction_imaginations_deque) > 0
+            ):
+                self.visualize_reconstruction_imaginations()
 
         self.step_data[DataKeys.OBSERVATION] = observation  # o_t
         self.step_data[DataKeys.EMBED_OBSERVATION] = embed_obs  # z_t
@@ -237,6 +274,18 @@ class MultiStepImaginationCuriosityImageAgent(BaseAgent[Tensor, Tensor]):
         ax.set_ylabel("global steps")
 
         self.logger.tensorboard.add_figure("agent/multistep-imagination-errors", fig, self.global_step)
+
+    def visualize_reconstruction_imaginations(self) -> None:
+        reconstructions = torch.stack(list(self.reconstruction_imaginations_deque))  # (H, T, C, H, W)
+        image_size = reconstructions.size()[-2:]
+        ground_truth = torch.stack(list(self.reconstruction_imaginations_ground_truth_deque))  # (H, C, H, W)
+        ground_truth = torchvision.transforms.v2.functional.resize(ground_truth, image_size)
+
+        log_images = torch.cat([ground_truth.unsqueeze(1), reconstructions], dim=1)  # (H, T+1, C, H, W)
+        log_images = log_images.flatten(0, 1)  # # ((H * T+1), C, H, W)
+        grid_image = torchvision.utils.make_grid(log_images, self.max_imagination_steps + 1)
+
+        self.logger.tensorboard.add_image("agent/multistep-imagination-recontructions", grid_image, self.global_step)
 
 
 def average_exponentially(rewards: Tensor, decay: float) -> Tensor:

--- a/ami/interactions/agents/multi_step_imagination_curiosity_agent.py
+++ b/ami/interactions/agents/multi_step_imagination_curiosity_agent.py
@@ -53,6 +53,9 @@ class MultiStepImaginationCuriosityImageAgent(BaseAgent[Tensor, Tensor]):
             log_reward_imaginations_every_n_steps: Number of steps between each logging of reward imaginations.
             log_reward_imaginations_max_history_size: Maximum number of reward imagination entries to keep in the log history.
             log_reward_imaginations_append_interval: Number of steps between each append to the reward imaginations log.
+            log_reconstruction_imaginations_every_n_steps: Number of steps between each logging of reconstruction imaginations.
+            log_reconstruction_imaginations_max_history_size: Maximum number of reconstruction imagination entries to keep in the log history.
+            log_reconstruction_imaginations_append_interval: Number of steps between each append to the reconstruction imaginations log.
         """
         super().__init__()
         assert max_imagination_steps > 0
@@ -276,6 +279,17 @@ class MultiStepImaginationCuriosityImageAgent(BaseAgent[Tensor, Tensor]):
         self.logger.tensorboard.add_figure("agent/multistep-imagination-errors", fig, self.global_step)
 
     def visualize_reconstruction_imaginations(self) -> None:
+        """Visualizes the reconstruction imaginations.
+
+        This method creates a grid of images showing the ground truth observations
+        alongside the reconstructed observations for each imagination step. The grid
+        is then logged to TensorBoard for visual analysis.
+
+        The visualization helps in understanding how well the agent's imagination
+        process is reconstructing observations over multiple steps, providing insights
+        into the quality of the agent's internal world model.
+        """
+
         reconstructions = torch.stack(list(self.reconstruction_imaginations_deque))  # (H, T, C, H, W)
         image_size = reconstructions.size()[-2:]
         ground_truth = torch.stack(list(self.reconstruction_imaginations_ground_truth_deque))  # (H, C, H, W)

--- a/configs/experiment/learn_only_sioconv.yaml
+++ b/configs/experiment/learn_only_sioconv.yaml
@@ -36,6 +36,9 @@ models:
       out_dim: 32
       depth: 12
       num_heads: 9
+  i_jepa_target_visualization_decoder:
+    inference_thread_only: True
+    parameter_file: null # 学習済モデルをセットする
   policy:
     model:
       file_max_rows: ${shared.frame_limit}

--- a/configs/interaction/agent/curiosity_image_multi_step_imagination.yaml
+++ b/configs/interaction/agent/curiosity_image_multi_step_imagination.yaml
@@ -17,6 +17,9 @@ max_imagination_steps: 50
 log_reward_imaginations_max_history_size: ${.max_imagination_steps}
 log_reward_imaginations_append_interval: 100
 log_reward_imaginations_every_n_steps: ${python.eval:"${.max_imagination_steps} * ${.log_reward_imaginations_append_interval}"}
+log_reconstruction_imaginations_max_history_size: ${.max_imagination_steps}
+log_reconstruction_imaginations_append_interval: 100
+log_reconstruction_imaginations_every_n_steps: ${python.eval:"${.max_imagination_steps} * ${.log_reconstruction_imaginations_append_interval}"}
 
 reward_average_method:
   _target_: ami.interactions.agents.multi_step_imagination_curiosity_agent.average_exponentially

--- a/configs/models/learn_only_sioconv.yaml
+++ b/configs/models/learn_only_sioconv.yaml
@@ -1,4 +1,5 @@
 image_encoder: i_jepa_target_encoder # Alias for ImageEncodingAgent.
+image_decoder: i_jepa_target_visualization_decoder # Alias for MultiStepCuriosityAgent.
 
 i_jepa_target_encoder:
   _target_: ami.models.model_wrapper.ModelWrapper
@@ -124,3 +125,22 @@ value:
       normal_cls:
         _target_: hydra.utils.get_class
         path: ami.models.components.fully_connected_fixed_std_normal.DeterministicNormal
+
+i_jepa_target_visualization_decoder:
+  _target_: ami.models.model_wrapper.ModelWrapper
+  default_device: ${devices.0}
+  parameter_file: ???
+  has_inference: True
+  model:
+    _target_: ami.models.i_jepa_latent_visualization_decoder.IJEPALatentVisualizationDecoder
+    input_n_patches:
+      - ${python.eval:"${shared.image_height} // ${models.i_jepa_target_encoder.model.patch_size}"}
+      - ${python.eval:"${shared.image_width} // ${models.i_jepa_target_encoder.model.patch_size}"}
+    input_latents_dim: ${models.i_jepa_target_encoder.model.out_dim}
+    decoder_blocks_in_and_out_channels:
+      - [512, 512]
+      - [512, 256]
+      - [256, 128]
+      - [128, 64]
+    n_res_blocks: 3
+    num_heads: 4

--- a/tests/interactions/agents/test_multi_step_imagination_curiosity_agent.py
+++ b/tests/interactions/agents/test_multi_step_imagination_curiosity_agent.py
@@ -19,6 +19,7 @@ from ami.interactions.agents.multi_step_imagination_curiosity_agent import (
 from ami.models.components.fully_connected_normal import FullyConnectedNormal
 from ami.models.components.sioconv import SioConv
 from ami.models.components.small_conv_net import SmallConvNet
+from ami.models.components.small_deconv_net import SmallDeconvNet
 from ami.models.policy_value_common_net import SelectObservation
 from ami.models.utils import InferenceWrappersDict, ModelWrapper, ModelWrappersDict
 from ami.tensorboard_loggers import TimeIntervalLogger
@@ -35,6 +36,7 @@ class TestMultiStepImaginationCuriosityImageAgent:
     @pytest.fixture
     def inference_models(self, device) -> InferenceWrappersDict:
         image_encoder = SmallConvNet(WIDTH, HEIGHT, CHANNELS, EMBED_OBS_DIM)
+        image_decoder = SmallDeconvNet(HEIGHT, WIDTH, CHANNELS, EMBED_OBS_DIM)
         forward_dynamics = ForwardDynamcisWithActionReward(
             nn.Identity(),
             nn.Identity(),
@@ -64,6 +66,7 @@ class TestMultiStepImaginationCuriosityImageAgent:
         mwd = ModelWrappersDict(
             {
                 ModelNames.IMAGE_ENCODER: ModelWrapper(image_encoder, device, True),
+                ModelNames.IMAGE_DECODER: ModelWrapper(image_decoder, device, True),
                 ModelNames.FORWARD_DYNAMICS: ModelWrapper(forward_dynamics, device, True),
                 ModelNames.POLICY: ModelWrapper(policy_net, device, True),
                 ModelNames.VALUE: ModelWrapper(value_net, device, True),


### PR DESCRIPTION
## 概要

#118 ~~全ての計算機を使用していたため動作確認がまだできていませんが、機能実装は終わったのでPR出します。~~
動作確認取れました。
![スクリーンショット 2024-09-09 午後4 38 29](https://github.com/user-attachments/assets/1dd16f2c-696c-4e8c-93d5-f31ca05f9f38)


## 変更内容

<!-- ビューの変更がある場合はスクショによる比較などがあるとわかりやすい -->

## 影響範囲

<!-- この関数を変更したのでこの機能にも影響がある、など -->

## Submit前の確認項目

<!-- PRをSubmitする前に確認する項目 -->

- [x] タイトルは一目でわかるようにし、説明文は PR を簡潔に説明するようにしましたか?
- [x] あなたの PR が、異なる変更を束ねたものではなく、ひとつのことだけを行うものであることを確認しましたか?
- [x] この PR で導入されたすべての変更点をリストアップしましたか?
- [x] PR を`make run`コマンドでローカルでテストしましたか?

## 補足

<!-- レビューをする際に見てほしい点、ローカル環境で試す際の注意点、など -->
