### PR TITLE
FullyConnectedNormalとMixtureDensityNetworkの重み初期化を修正

### DIFF
--- a/ami/models/components/fully_connected_normal.py
+++ b/ami/models/components/fully_connected_normal.py
@@ -16,6 +16,9 @@ class FullyConnectedNormal(nn.Module):
         self.eps = eps
         self.squeeze_feature_dim = squeeze_feature_dim
 
+        nn.init.zeros_(self.fc_std.weight)
+        nn.init.ones_(self.fc_std.bias)
+
     def forward(self, x: Tensor) -> Normal:
         mean: Tensor = self.fc_mean(x)
         std: Tensor = nn.functional.softplus(self.fc_std(x)) + self.eps

--- a/ami/models/components/mixture_desity_network.py
+++ b/ami/models/components/mixture_desity_network.py
@@ -116,6 +116,23 @@ class NormalMixtureDensityNetwork(nn.Module):
         self.squeeze_feature_dim = squeeze_feature_dim
         self.eps = eps
 
+        self._init_weights()
+
+    def _init_weights(self) -> None:
+        """Initialize the weights.
+
+        The sigma layer will output to 1, and logits layer will output
+        uniform distribution.
+        """
+        layer: nn.Linear
+        for layer in self.sigma_layers:
+            nn.init.zeros_(layer.weight)
+            nn.init.ones_(layer.bias)
+
+        for layer in self.logits_layers:
+            nn.init.zeros_(layer.weight)
+            nn.init.zeros_(layer.bias)
+
     def forward(self, x: Tensor) -> NormalMixture:
         mu = torch.stack([lyr(x) for lyr in self.mu_layers], dim=-1)
         sigma = torch.stack([F.softplus(lyr(x)) for lyr in self.sigma_layers], dim=-1) + self.eps

--- a/tests/models/components/test_fully_connected_normal.py
+++ b/tests/models/components/test_fully_connected_normal.py
@@ -12,6 +12,7 @@ class TestFullyConnectedNormal:
         out = m(data)
         assert isinstance(out, Normal)
         assert out.rsample().shape == (batch_size, dim_out)
+        assert torch.allclose(out.stddev, torch.nn.functional.softplus(torch.ones_like(out.stddev)))
 
     def test_squeeze_feature_dim(self):
         with pytest.raises(AssertionError):

--- a/tests/models/components/test_mixture_density_network.py
+++ b/tests/models/components/test_mixture_density_network.py
@@ -91,6 +91,10 @@ class TestNormalMixtureDensityNetwork:
         # Check that log_pi is a valid log probability
         assert torch.allclose(output.log_pi.exp().sum(dim=-1), torch.ones(batch_size, out_features))
 
+        # Check the initial outputs
+        assert torch.allclose(output.sigma, torch.nn.functional.softplus(torch.ones_like(output.sigma)))
+        assert torch.allclose(output.logits, torch.zeros_like(output.logits))
+
     def test_normal_mixture_density_network_gradients(self):
         in_features, out_features, num_components = 10, 5, 3
         network = NormalMixtureDensityNetwork(in_features, out_features, num_components)


### PR DESCRIPTION
## 概要

Forward Dynamicsの予測誤差が非常に大きい値になりnanになるバグが発生していた。その原因調査の過程で、正規分布の標準偏差が0に近い値に出力される可能性があることに気づいたため、修正した。

標準偏差は初期化後は常に1を返すようにした。
MixtureDensityNetworkの初期の混合割合分布は一様分布になるようにした。

## 変更内容

<!-- ビューの変更がある場合はスクショによる比較などがあるとわかりやすい -->

## 影響範囲

<!-- この関数を変更したのでこの機能にも影響がある、など -->

## Submit前の確認項目

<!-- PRをSubmitする前に確認する項目 -->

- [x] タイトルは一目でわかるようにし、説明文は PR を簡潔に説明するようにしましたか?
- [x] あなたの PR が、異なる変更を束ねたものではなく、ひとつのことだけを行うものであることを確認しましたか?
- [x] この PR で導入されたすべての変更点をリストアップしましたか?
- [x] PR を`make run`コマンドでローカルでテストしましたか?

## 補足

<!-- レビューをする際に見てほしい点、ローカル環境で試す際の注意点、など -->
