### PR TITLE
想像軌道で実際に環境に作用させたactionを使うよう修正

### DIFF
--- a/ami/interactions/agents/multi_step_imagination_curiosity_agent.py
+++ b/ami/interactions/agents/multi_step_imagination_curiosity_agent.py
@@ -189,13 +189,14 @@ class MultiStepImaginationCuriosityImageAgent(BaseAgent[Tensor, Tensor]):
         )
         action_imaginations = action_dist_imaginations.sample()
         action_log_prob_imaginations = action_dist_imaginations.log_prob(action_imaginations)
+        actions = action_imaginations[0].expand_as(action_imaginations)  # 実際に環境に作用させるactionだけを抽出
 
         pred_obs_dist_imaginations, _, _, next_hidden_imaginations = self.forward_dynamics(
-            embed_obs_imaginations, hidden_imaginations, action_imaginations
+            embed_obs_imaginations, hidden_imaginations, actions  # 実際に環境に作用させるactionだけを使用
         )
         pred_obs_imaginations = pred_obs_dist_imaginations.sample()
 
-        self.step_data[DataKeys.ACTION] = action_imaginations[0]  # a_t
+        self.step_data[DataKeys.ACTION] = actions[0]  # a_t
         self.step_data[DataKeys.ACTION_LOG_PROBABILITY] = action_log_prob_imaginations[0]  # log \pi(a_t | o_t, h_t)
         self.step_data[DataKeys.VALUE] = value_imaginations[0]  # v_t
         self.step_data[DataKeys.HIDDEN] = self.exact_forward_dynamics_hidden_state  # h_t
@@ -208,7 +209,7 @@ class MultiStepImaginationCuriosityImageAgent(BaseAgent[Tensor, Tensor]):
 
         self.logger.update()
 
-        return action_imaginations[0]
+        return actions[0]
 
     def setup(self, observation: Tensor) -> Tensor:
         super().setup(observation)


### PR DESCRIPTION
## 概要

想像したの観測と隠れ状態から出力した行動を使ってしまっていたため、実際に環境に作用させた行動のみを使うように修正した。

## 変更内容

<!-- ビューの変更がある場合はスクショによる比較などがあるとわかりやすい -->

## 影響範囲

<!-- この関数を変更したのでこの機能にも影響がある、など -->

## Submit前の確認項目

<!-- PRをSubmitする前に確認する項目 -->

- [x] タイトルは一目でわかるようにし、説明文は PR を簡潔に説明するようにしましたか?
- [x] あなたの PR が、異なる変更を束ねたものではなく、ひとつのことだけを行うものであることを確認しましたか?
- [x] この PR で導入されたすべての変更点をリストアップしましたか?
- [x] PR を`make run`コマンドでローカルでテストしましたか?

## 補足

<!-- レビューをする際に見てほしい点、ローカル環境で試す際の注意点、など -->
