### PR TITLE
MultiStepImaginationCuriosityAgentのvisualization loggingをリファクタリング

### DIFF
--- a/ami/interactions/agents/multi_step_imagination_curiosity_agent.py
+++ b/ami/interactions/agents/multi_step_imagination_curiosity_agent.py
@@ -310,7 +310,7 @@ class MultiStepImaginationCuriosityImageAgent(BaseAgent[Tensor, Tensor]):
 
         log_images = torch.cat([ground_truth.unsqueeze(1), reconstructions], dim=1)  # (H, T+1, C, H, W)
         log_images = log_images.flatten(0, 1)  # # ((H * T+1), C, H, W)
-        grid_image = torchvision.utils.make_grid(log_images, self.max_imagination_steps + 1)
+        grid_image = torchvision.utils.make_grid(log_images, self.max_imagination_steps + 1, normalize=True)
 
         self.logger.tensorboard.add_image("agent/multistep-imagination-recontructions", grid_image, self.global_step)
 

--- a/ami/interactions/agents/multi_step_imagination_curiosity_agent.py
+++ b/ami/interactions/agents/multi_step_imagination_curiosity_agent.py
@@ -15,6 +15,7 @@ from torch.distributions import Distribution
 from typing_extensions import override
 
 from ami.tensorboard_loggers import TimeIntervalLogger
+from ami.utils import min_max_normalize
 
 from ...data.step_data import DataKeys, StepData
 from ...models.forward_dynamics import ForwardDynamcisWithActionReward
@@ -325,6 +326,7 @@ class MultiStepImaginationCuriosityImageAgent(BaseAgent[Tensor, Tensor]):
 
         log_images = torch.cat([ground_truth.unsqueeze(1), reconstructions], dim=1)  # (H, T+1, C, H, W)
         log_images = log_images.flatten(0, 1)  # # ((H * T+1), C, H, W)
+        log_images = min_max_normalize(log_images.flatten(1), 0, 1, dim=-1).reshape(log_images.shape)
         grid_image = torchvision.utils.make_grid(log_images, self.max_imagination_steps + 1, normalize=True)
 
         self.logger.tensorboard.add_image("agent/multistep-imagination-recontructions", grid_image, self.global_step)

--- a/ami/interactions/agents/multi_step_imagination_curiosity_agent.py
+++ b/ami/interactions/agents/multi_step_imagination_curiosity_agent.py
@@ -52,9 +52,11 @@ class MultiStepImaginationCuriosityImageAgent(BaseAgent[Tensor, Tensor]):
             reward_average_method: The method for averaging rewards that predicted through multi imaginations.
                 Input is reward (imagination, ), and return value must be scalar.
             max_imagination_steps: Max step for imagination.
+            log_reward_imaginations: Flag to enable logging of reward imaginations.
             log_reward_imaginations_every_n_steps: Number of steps between each logging of reward imaginations.
             log_reward_imaginations_max_history_size: Maximum number of reward imagination entries to keep in the log history.
             log_reward_imaginations_append_interval: Number of steps between each append to the reward imaginations log.
+            log_reconstruction_imaginations: Flag to enable logging of reconstruction imaginations.
             log_reconstruction_imaginations_every_n_steps: Number of steps between each logging of reconstruction imaginations.
             log_reconstruction_imaginations_max_history_size: Maximum number of reconstruction imagination entries to keep in the log history.
             log_reconstruction_imaginations_append_interval: Number of steps between each append to the reconstruction imaginations log.
@@ -215,6 +217,12 @@ class MultiStepImaginationCuriosityImageAgent(BaseAgent[Tensor, Tensor]):
         )
 
     def reward_imaginations_logging_step(self, reward_imaginations: Tensor) -> None:
+        """Logs reward imaginations data and visualizes it at specified
+        intervals.
+
+        Args:
+            reward_imaginations: Tensor containing reward imagination values.
+        """
         # 長期的予測の誤差値とそのステップの格納
         if (
             reward_imaginations.size(0) == self.max_imagination_steps
@@ -275,6 +283,13 @@ class MultiStepImaginationCuriosityImageAgent(BaseAgent[Tensor, Tensor]):
     def reconstruction_imaginations_logging_step(
         self, observation: Tensor, image_decoder: ThreadSafeInferenceWrapper[nn.Module]
     ) -> None:
+        """Logs reconstruction imaginations and visualizes them at specified
+        intervals.
+
+        Args:
+            observation: Current observation tensor.
+            image_decoder: Image decoder model for reconstructions.
+        """
         # 長期的予測の再構成画像とそのGround Truthの格納
         if (
             self.predicted_embed_obs_imaginations.size(0) == self.max_imagination_steps

--- a/configs/interaction/agent/curiosity_image_multi_step_imagination.yaml
+++ b/configs/interaction/agent/curiosity_image_multi_step_imagination.yaml
@@ -14,9 +14,11 @@ logger:
   log_every_n_seconds: 0
 
 max_imagination_steps: 50
+log_reward_imaginations: True
 log_reward_imaginations_max_history_size: ${.max_imagination_steps}
 log_reward_imaginations_append_interval: 100
 log_reward_imaginations_every_n_steps: ${python.eval:"${.max_imagination_steps} * ${.log_reward_imaginations_append_interval}"}
+log_reconstruction_imaginations: True
 log_reconstruction_imaginations_max_history_size: ${.max_imagination_steps}
 log_reconstruction_imaginations_append_interval: 100
 log_reconstruction_imaginations_every_n_steps: ${python.eval:"${.max_imagination_steps} * ${.log_reconstruction_imaginations_append_interval}"}


### PR DESCRIPTION
## 概要

visualizationの処理が `step`メソッドを読みにくくしてしまっていたためメソッドに分割した。
また、 #132 で make_gridを`normalize=True`とするようにしていたため、それも合わせて変更した。

## 変更内容

<!-- ビューの変更がある場合はスクショによる比較などがあるとわかりやすい -->

## 影響範囲

<!-- この関数を変更したのでこの機能にも影響がある、など -->

## Submit前の確認項目

<!-- PRをSubmitする前に確認する項目 -->

- [ ] タイトルは一目でわかるようにし、説明文は PR を簡潔に説明するようにしましたか?
- [ ] あなたの PR が、異なる変更を束ねたものではなく、ひとつのことだけを行うものであることを確認しましたか?
- [ ] この PR で導入されたすべての変更点をリストアップしましたか?
- [ ] PR を`make run`コマンドでローカルでテストしましたか?

## 補足

<!-- レビューをする際に見てほしい点、ローカル環境で試す際の注意点、など -->
