### PR TITLE
batch_sizeでseqlenとsample数がスケールするよう設定

### DIFF
--- a/configs/experiment/learn_only_sioconv.yaml
+++ b/configs/experiment/learn_only_sioconv.yaml
@@ -78,8 +78,10 @@ trainers:
     observation_encoder_name: null # embed observationを直接使う
     max_epochs: 1
     partial_sampler:
-      sequence_length: ${python.eval:"256 + 1"} # +1 to generate future target data.
-      max_samples: 64 # Iteraction count.
+      sequence_length: ${python.eval:"256 // ${..partial_dataloader.batch_size} + 1"} # +1 to generate future target data.
+      max_samples: ${python.eval:"64 * ${..partial_dataloader.batch_size}"} # 64 is Iteraction count.
     minimum_new_data_count: 128
+    partial_dataloader:
+      batch_size: 1
 
 task_name: "learn_only_sioconv"


### PR DESCRIPTION
## 概要

バッチサイズと系列長のトレードオフによる性能変化を見るためにconfigを変更しました。
さほど性能に変化は見られませんでしたが、気持ち バッチサイズ1, 系列長を最大にしたものが損失が一番低かったです。

## 変更内容

<!-- ビューの変更がある場合はスクショによる比較などがあるとわかりやすい -->

## 影響範囲

<!-- この関数を変更したのでこの機能にも影響がある、など -->

## Submit前の確認項目

<!-- PRをSubmitする前に確認する項目 -->

- [x] タイトルは一目でわかるようにし、説明文は PR を簡潔に説明するようにしましたか?
- [x] あなたの PR が、異なる変更を束ねたものではなく、ひとつのことだけを行うものであることを確認しましたか?
- [x] この PR で導入されたすべての変更点をリストアップしましたか?
- [x] PR を`make run`コマンドでローカルでテストしましたか?

## 補足

<!-- レビューをする際に見てほしい点、ローカル環境で試す際の注意点、など -->
