### PR TITLE
予測誤差の曲線をプロットする処理を追加

### DIFF
--- a/ami/interactions/agents/multi_step_imagination_curiosity_agent.py
+++ b/ami/interactions/agents/multi_step_imagination_curiosity_agent.py
@@ -383,7 +383,7 @@ class MultiStepImaginationCuriosityImageAgent(BaseAgent[Tensor, Tensor]):
         )
         ax3.legend()
         self.logger.tensorboard.add_figure(
-            "agent/multistep-reward-imaginations--curves (normalized & averaged)", fig3, self.global_step
+            "agent/multistep-reward-imaginations-curves (normalized & averaged)", fig3, self.global_step
         )
 
     def reconstruction_imaginations_logging_step(

--- a/ami/interactions/agents/multi_step_imagination_curiosity_agent.py
+++ b/ami/interactions/agents/multi_step_imagination_curiosity_agent.py
@@ -354,7 +354,7 @@ class MultiStepImaginationCuriosityImageAgent(BaseAgent[Tensor, Tensor]):
             color = cmap(norm(global_steps[i]))
             ax1.plot(x_indices, curve, color=color)
         fig1.colorbar(ScalarMappable(cmap=cmap, norm=norm), ax=ax1, label="Global Steps", pad=0.1)
-        self.logger.tensorboard.add_figure("agent/multistep-imaginations-error-curves", fig1, self.global_step)
+        self.logger.tensorboard.add_figure("agent/multistep-reward-imaginations-curves", fig1, self.global_step)
 
         # 正規化された曲線プロット
         fig2, ax2 = create_figure("Normalized Reward Imaginations", "Normalized Reward")
@@ -364,7 +364,7 @@ class MultiStepImaginationCuriosityImageAgent(BaseAgent[Tensor, Tensor]):
             ax2.set_ylim(top=1.0)
         fig2.colorbar(ScalarMappable(cmap=cmap, norm=norm), ax=ax2, label="Global Steps", pad=0.1)
         self.logger.tensorboard.add_figure(
-            "agent/multistep-imaginations-error-curves (normalized)", fig2, self.global_step
+            "agent/multistep-reward-imaginations-curves (normalized)", fig2, self.global_step
         )
 
         # 平均化された正規化曲線プロット
@@ -383,7 +383,7 @@ class MultiStepImaginationCuriosityImageAgent(BaseAgent[Tensor, Tensor]):
         )
         ax3.legend()
         self.logger.tensorboard.add_figure(
-            "agent/multistep-imaginations-error-curves (averaged)", fig3, self.global_step
+            "agent/multistep-reward-imaginations--curves (normalized & averaged)", fig3, self.global_step
         )
 
     def reconstruction_imaginations_logging_step(


### PR DESCRIPTION
## 概要

複数ステップにかけて予測誤差を計算する場合に何ステップまで考慮するべきかを考えるために、誤差曲線をプロットする処理を追加しました。

<!-- 変更の目的 もしくは 関連する Issue 番号 -->
![image](https://github.com/user-attachments/assets/eced7da9-f88e-4222-a3e0-b64777d95001)
![image](https://github.com/user-attachments/assets/ff61f591-9621-48dd-94a1-314c464ffde5)
![image](https://github.com/user-attachments/assets/fee6e1a0-9e8e-4abf-b921-b49111b77c6c)


## 変更内容

<!-- ビューの変更がある場合はスクショによる比較などがあるとわかりやすい -->

## 影響範囲

<!-- この関数を変更したのでこの機能にも影響がある、など -->

## Submit前の確認項目

<!-- PRをSubmitする前に確認する項目 -->

- [ ] タイトルは一目でわかるようにし、説明文は PR を簡潔に説明するようにしましたか?
- [ ] あなたの PR が、異なる変更を束ねたものではなく、ひとつのことだけを行うものであることを確認しましたか?
- [ ] この PR で導入されたすべての変更点をリストアップしましたか?
- [ ] PR を`make run`コマンドでローカルでテストしましたか?

## 補足

<!-- レビューをする際に見てほしい点、ローカル環境で試す際の注意点、など -->
