### PR TITLE
Policyの収束・発散実験での変更

### DIFF
--- a/ami/interactions/environments/actuators/vrchat_osc_discrete_actuator.py
+++ b/ami/interactions/environments/actuators/vrchat_osc_discrete_actuator.py
@@ -8,6 +8,7 @@ from vrchat_io.controller.wrappers.osc import MultiInputWrapper
 from .base_actuator import BaseActuator
 
 ACTION_CHOICES_PER_CATEGORY = [3, 3, 3, 2, 2]
+ACTION_CHOICES_PER_CATEGORY_MASKED_JUMP_RUN = [3, 3, 3, 1, 1]  # 去年のAMIと行動設定を合わせるため。
 
 STOP_ACTION = torch.tensor(
     [

--- a/ami/interactions/io_wrappers/tensor_csv_recorder.py
+++ b/ami/interactions/io_wrappers/tensor_csv_recorder.py
@@ -1,4 +1,5 @@
 import csv
+import os
 import time
 from typing import Any, Callable, Generic, TypeVar
 
@@ -30,6 +31,7 @@ class TensorCSVRecorder(BaseIOWrapper[Tensor, Tensor]):
     @override
     def __init__(self, filename: str, headers: list[str], timestamp_header: str = "timestamp") -> None:
         super().__init__()
+        os.makedirs(os.path.dirname(filename), exist_ok=True)
         self.filename = filename
         self.headers = [timestamp_header] + headers
         self._initialize_csv()

--- a/configs/experiment/i_jepa_sioconv_ppo_multi_step.yaml
+++ b/configs/experiment/i_jepa_sioconv_ppo_multi_step.yaml
@@ -22,6 +22,10 @@ shared:
 interaction:
   agent:
     max_imagination_steps: 1 # * 0.1 = seconds.
+    # 行動に大きなラグが発生するので無効化
+    log_reward_imaginations: False
+    log_reconstruction_imaginations: False
+    log_imagination_trajectory: False
 
   observation_wrappers:
     - _target_: ami.interactions.io_wrappers.tensor_video_recorder.TensorVideoRecorder

--- a/configs/experiment/i_jepa_sioconv_ppo_multi_step.yaml
+++ b/configs/experiment/i_jepa_sioconv_ppo_multi_step.yaml
@@ -24,11 +24,28 @@ interaction:
     max_imagination_steps: 50 # 5 sec
 
   observation_wrappers:
+    - _target_: ami.interactions.io_wrappers.tensor_video_recorder.TensorVideoRecorder
+      output_dir: ${paths.io_log_dir}/video_recordings
+      width: ${shared.image_width}
+      height: ${shared.image_height}
+      frame_rate: ${python.eval:"1 / ${interaction.interval_adjustor.interval}"}
+
     - _target_: ami.interactions.io_wrappers.function_wrapper.FunctionIOWrapper
       wrap_function:
         _target_: ami.interactions.io_wrappers.function_wrapper.normalize_tensor
         _partial_: True
         eps: 1e-6
+
+  action_wrappers:
+    - _target_: ami.interactions.io_wrappers.tensor_csv_recorder.TensorCSVRecorder
+      filename: ${paths.io_log_dir}/action_log.csv
+      timestamp_header: "Timestamp"
+      headers:
+        - "MoveVertical"
+        - "MoveHorizontal"
+        - "LookHorizontal"
+        - "Jump"
+        - "Run"
 
 data_collectors:
   image:

--- a/configs/experiment/i_jepa_sioconv_ppo_multi_step.yaml
+++ b/configs/experiment/i_jepa_sioconv_ppo_multi_step.yaml
@@ -21,7 +21,7 @@ shared:
 
 interaction:
   agent:
-    max_imagination_steps: 50 # 5 sec
+    max_imagination_steps: 1 # * 0.1 = seconds.
 
   observation_wrappers:
     - _target_: ami.interactions.io_wrappers.tensor_video_recorder.TensorVideoRecorder

--- a/configs/experiment/i_jepa_sioconv_ppo_multi_step.yaml
+++ b/configs/experiment/i_jepa_sioconv_ppo_multi_step.yaml
@@ -21,6 +21,7 @@ shared:
 
 interaction:
   agent:
+    # 旧 AMI の設定と同期
     max_imagination_steps: 1 # * 0.1 = seconds.
     # 行動に大きなラグが発生するので無効化
     log_reward_imaginations: False

--- a/configs/hydra/default.yaml
+++ b/configs/hydra/default.yaml
@@ -57,6 +57,3 @@ job_logging:
       filename: ${hydra.runtime.output_dir}/inference.log
       when: D
       formatter: simple
-
-launcher:
-  n_jobs: ${python.eval:"${os.cpu_count:} // 4"}

--- a/configs/interaction/environment/dummy_image_io.yaml
+++ b/configs/interaction/environment/dummy_image_io.yaml
@@ -1,12 +1,11 @@
 _target_: ami.interactions.environments.dummy_environment.DummyEnvironment
 observation_generator:
-  _target_: ami.interactions.environments.dummy_environment.SameObservationGenerator
-  observation:
-    _target_: torch.zeros
-    _args_:
-      - ${shared.image_channels}
-      - ${shared.image_height}
-      - ${shared.image_width}
+  _partial_: true
+  _target_: torch.zeros
+  _args_:
+    - ${shared.image_channels}
+    - ${shared.image_height}
+    - ${shared.image_width}
 
 action_checker:
   _target_: ami.interactions.environments.dummy_environment.ActionTypeChecker

--- a/configs/trainers/ppo/default.yaml
+++ b/configs/trainers/ppo/default.yaml
@@ -20,3 +20,4 @@ logger:
 device: ${devices.0}
 max_epochs: 3
 minimum_dataset_size: ${python.eval:"${data_collectors.ppo_trajectory.max_len} - 1"}
+entropy_coef: 0.001

--- a/scripts/run_experiment_gamma_scale.sh
+++ b/scripts/run_experiment_gamma_scale.sh
@@ -1,0 +1,29 @@
+gammas=(0.5 0.7 0.8 0.9)
+
+# Simple World
+for g in "${gammas[@]}"
+do
+    python scripts/launch.py experiment=i_jepa_sioconv_ppo_multi_step \
+        max_uptime=18000 \
+        interaction/environment=unity \
+        interaction.environment.file_path=/workspace/unity_executables/SimpleWorld/SimpleWorld.x86_64 \
+        models=i_jepa_sioconv_resnetpolicy_small \
+        hydra.mode=MULTIRUN \
+        hydra.launcher.n_jobs=1 \
+        data_collectors.ppo_trajectory.gamma=$g \
+        time_scale=4,4,4 # Run 3 times
+done
+
+# Noisy World
+for g in "${gammas[@]}"
+do
+    python scripts/launch.py experiment=i_jepa_sioconv_ppo_multi_step \
+        max_uptime=18000 \
+        interaction/environment=unity \
+        interaction.environment.file_path=/workspace/unity_executables/MeshiTeroNoisyWorld/MeshiTeroNoisyWorld.x86_64 \
+        models=i_jepa_sioconv_resnetpolicy_small \
+        hydra.mode=MULTIRUN \
+        hydra.launcher.n_jobs=1 \
+        data_collectors.ppo_trajectory.gamma=$g \
+        time_scale=4,4,4 # Run 3 times
+done


### PR DESCRIPTION
## 概要

#146 Policyの収束・発散実験での変更点をPRします．

## 変更内容

* ACTION_CHOICES_PER_CATEGORY_MASKED_JUMP_RUNを追加し，去年のAMIの行動設定に近しい設定で実行可能にしました．
* 観測および行動を記録するようにしました．
* 想像上の報酬の記録処理は大きな推論ラグを断続的に生じてしまうため，今回の設計ではデフォルトで無効にしました．
* 割引率gammaが学習の収束速度に大きく影響している事が確認されたため，それを調べるための実行スクリプトを追加しました．
* その他，軽微な修正です．

## 影響範囲

<!-- この関数を変更したのでこの機能にも影響がある、など -->

## Submit前の確認項目

<!-- PRをSubmitする前に確認する項目 -->

- [x] タイトルは一目でわかるようにし、説明文は PR を簡潔に説明するようにしましたか?
- [x] あなたの PR が、異なる変更を束ねたものではなく、ひとつのことだけを行うものであることを確認しましたか?
- [x] この PR で導入されたすべての変更点をリストアップしましたか?
- [x] PR を`make run`コマンドでローカルでテストしましたか?

## 補足

<!-- レビューをする際に見てほしい点、ローカル環境で試す際の注意点、など -->
