### PR TITLE
I-JEPAの潜在空間をpatch軸に対してmeanする実装を追加

### DIFF
--- a/ami/hydra_instantiators.py
+++ b/ami/hydra_instantiators.py
@@ -133,6 +133,9 @@ def instantiate_trainers(trainers_cfg: DictConfig | None) -> TrainersList:
         return tl
 
     for i, (name, cfg) in enumerate(trainers_cfg.items()):
+        if cfg is None:
+            logger.info(f"Trainer[{i}] {name!r} is null. passing...")
+            continue
         logger.info(f"Instatiating Trainer[{i}] {name!r}: <{cfg._target_}>")
         trainer: BaseTrainer = hydra.utils.instantiate(cfg)
         trainer.name = str(name)

--- a/ami/models/i_jepa_latent_visualization_decoder.py
+++ b/ami/models/i_jepa_latent_visualization_decoder.py
@@ -254,3 +254,29 @@ class IJEPALatentVisualizationDecoder(nn.Module):
         if no_batch:
             output = output.squeeze(0)
         return output
+
+
+class IJEPAMeanLatentAlongPatchVisualizationDecoder(IJEPALatentVisualizationDecoder):
+    """Decodes from a latent representation averaged along the patch axis."""
+
+    def forward(self, input_latents: torch.Tensor) -> torch.Tensor:
+        """Generate images from input latents.
+        Args:
+            input_latents (torch.Tensor):
+                latents from other decoder model.
+                (shape: [batch_size, latents_dim])
+        Returns:
+            torch.Tensor:
+                Generated images.
+                (shape:
+                    [
+                        batch_size,
+                        3,
+                        n_patches_height * (2**(len(decoder_blocks_in_and_out_channels)-1)),
+                        n_patches_width * (2**(len(decoder_blocks_in_and_out_channels)-1)),
+                    ]
+                )
+        """
+        num_patch = self.input_n_patches[0] * self.input_n_patches[1]
+        input_latents = input_latents.unsqueeze(-2).expand(*input_latents.shape[:-1], num_patch, self.input_latents_dim)
+        return super().forward(input_latents)

--- a/ami/models/i_jepa_latent_visualization_decoder.py
+++ b/ami/models/i_jepa_latent_visualization_decoder.py
@@ -148,6 +148,7 @@ class IJEPALatentVisualizationDecoder(nn.Module):
         decoder_blocks_in_and_out_channels: list[tuple[int, int]],
         n_res_blocks: int,
         num_heads: int,
+        num_norm_groups: int = 32,
     ) -> None:
         """Decoder for visualizing latents as image.
 
@@ -174,6 +175,8 @@ class IJEPALatentVisualizationDecoder(nn.Module):
         self.input_resblock_1 = ResBlock(
             in_channels=input_latents_dim,
             out_channels=decoder_blocks_first_n_channels,
+            num_norm_groups_in_input_layer=num_norm_groups,
+            num_norm_groups_in_output_layer=num_norm_groups,
         )
         self.input_attention = nn.MultiheadAttention(
             embed_dim=decoder_blocks_first_n_channels,
@@ -183,6 +186,8 @@ class IJEPALatentVisualizationDecoder(nn.Module):
         self.input_resblock_2 = ResBlock(
             in_channels=decoder_blocks_first_n_channels,
             out_channels=decoder_blocks_first_n_channels,
+            num_norm_groups_in_input_layer=num_norm_groups,
+            num_norm_groups_in_output_layer=num_norm_groups,
         )
 
         # define decoder blocks
@@ -201,7 +206,7 @@ class IJEPALatentVisualizationDecoder(nn.Module):
         # define output blocks
         decoder_blocks_last_n_channels = decoder_blocks_in_and_out_channels[-1][-1]
         self.output_layer = nn.Sequential(
-            nn.GroupNorm(num_groups=32, num_channels=decoder_blocks_last_n_channels),
+            nn.GroupNorm(num_groups=num_norm_groups, num_channels=decoder_blocks_last_n_channels),
             nn.SiLU(),
             nn.Conv2d(decoder_blocks_last_n_channels, 3, kernel_size=3, padding=1),
         )

--- a/ami/models/instantiations.py
+++ b/ami/models/instantiations.py
@@ -253,3 +253,126 @@ def i_jepa_mean_patch_sioconv_resnetpolicy(
             ),
         ),
     }
+
+
+def i_jepa_mean_patch(
+    device: torch.device = CPU_DEVICE,
+    img_size: size_2d = (144, 144),  # (height, width)
+    in_channels: int = 3,
+    patch_size: size_2d = (12, 12),  # (height, width)
+    i_jepa_encoder: dict[str, Any] = {},
+    i_jepa_predictor: dict[str, Any] = {},
+    i_jepa_decoder: dict[str, Any] = {},
+) -> InstantiationReturnType:
+
+    # Defining nested dict config.
+    @dataclass
+    class IJEPAEncoderConfig:
+        embed_dim: int = 216
+        out_dim: int = 216
+        depth: int = 6
+        num_heads: int = 3
+        mlp_ratio: float = 4.0
+
+    @dataclass
+    class IJEPAPredictorConfig:
+        hidden_dim: int = 108
+        depth: int = 6
+        num_heads: int = 2
+
+    @dataclass
+    class IJEPADecoderConfig:
+        decoder_blocks_in_and_out_channels: list[tuple[int, int]] | None = None
+        n_res_blocks: int = 3
+        num_heads: int = 4
+        num_norm_groups: int = 8
+
+    default_decoder_blocks_in_and_out_channels = [
+        (512, 512),
+        (512, 256),
+        (256, 128),
+        (128, 64),
+    ]
+
+    i_jepa_encoder_cfg = IJEPAEncoderConfig(**i_jepa_encoder)
+    i_jepa_predictor_cfg = IJEPAPredictorConfig(**i_jepa_predictor)
+    i_jepa_decoder_cfg = IJEPADecoderConfig(**i_jepa_decoder)
+
+    if i_jepa_decoder_cfg.decoder_blocks_in_and_out_channels is None:
+        i_jepa_decoder_cfg.decoder_blocks_in_and_out_channels = default_decoder_blocks_in_and_out_channels
+
+    # import dependencies
+
+    from .bool_mask_i_jepa import (
+        BoolMaskIJEPAEncoder,
+        BoolTargetIJEPAPredictor,
+        encoder_infer_mean_along_patch,
+    )
+    from .i_jepa_latent_visualization_decoder import (
+        IJEPAMeanLatentAlongPatchVisualizationDecoder,
+    )
+
+    img_size = size_2d_to_int_tuple(img_size)
+    patch_size = size_2d_to_int_tuple(patch_size)
+
+    n_patch_vertical, r = divmod(img_size[0], patch_size[0])
+    assert r == 0
+    n_patch_horizontal, r = divmod(img_size[1], patch_size[1])
+    assert r == 0
+    n_patches = (n_patch_vertical, n_patch_horizontal)
+
+    i_jepa_encoder_model = BoolMaskIJEPAEncoder(
+        img_size=img_size,
+        patch_size=patch_size,
+        in_channels=in_channels,
+        embed_dim=i_jepa_encoder_cfg.embed_dim,
+        out_dim=i_jepa_encoder_cfg.out_dim,
+        depth=i_jepa_encoder_cfg.depth,
+        num_heads=i_jepa_encoder_cfg.num_heads,
+        mlp_ratio=i_jepa_encoder_cfg.mlp_ratio,
+    )
+
+    i_jepa_decoder_model = IJEPAMeanLatentAlongPatchVisualizationDecoder(
+        n_patches,
+        i_jepa_encoder_cfg.out_dim,
+        decoder_blocks_in_and_out_channels=i_jepa_decoder_cfg.decoder_blocks_in_and_out_channels,
+        n_res_blocks=i_jepa_decoder_cfg.n_res_blocks,
+        num_heads=i_jepa_decoder_cfg.num_heads,
+        num_norm_groups=i_jepa_decoder_cfg.num_norm_groups,
+    )
+
+    return {
+        ModelNames.IMAGE_ENCODER: ModelNames.I_JEPA_TARGET_ENCODER,  # Alias for agent.
+        ModelNames.I_JEPA_TARGET_ENCODER: ModelWrapper(
+            default_device=device,
+            has_inference=True,
+            inference_forward=encoder_infer_mean_along_patch,
+            model=i_jepa_encoder_model,
+        ),
+        ModelNames.I_JEPA_CONTEXT_ENCODER: ModelWrapper(
+            default_device=device,
+            has_inference=False,
+            model=copy.deepcopy(i_jepa_encoder_model),
+        ),
+        ModelNames.I_JEPA_PREDICTOR: ModelWrapper(
+            default_device=device,
+            has_inference=False,
+            model=BoolTargetIJEPAPredictor(
+                n_patches=n_patches,
+                context_encoder_out_dim=i_jepa_encoder_cfg.out_dim,
+                hidden_dim=i_jepa_predictor_cfg.hidden_dim,
+                depth=i_jepa_predictor_cfg.depth,
+                num_heads=i_jepa_predictor_cfg.num_heads,
+            ),
+        ),
+        ModelNames.I_JEPA_TARGET_VISUALIZATION_DECODER: ModelWrapper(
+            default_device=device,
+            has_inference=False,
+            model=i_jepa_decoder_model,
+        ),
+        ModelNames.I_JEPA_CONTEXT_VISUALIZATION_DECODER: ModelWrapper(
+            default_device=device,
+            has_inference=False,
+            model=copy.deepcopy(i_jepa_decoder_model),
+        ),
+    }

--- a/ami/models/instantiations.py
+++ b/ami/models/instantiations.py
@@ -351,6 +351,7 @@ def i_jepa_mean_patch(
         ),
         ModelNames.I_JEPA_CONTEXT_ENCODER: ModelWrapper(
             default_device=device,
+            inference_forward=encoder_infer_mean_along_patch,
             has_inference=False,
             model=copy.deepcopy(i_jepa_encoder_model),
         ),

--- a/configs/experiment/i_jepa_mean_patch_sioconv_ppo_multi_step.yaml
+++ b/configs/experiment/i_jepa_mean_patch_sioconv_ppo_multi_step.yaml
@@ -21,7 +21,7 @@ shared:
 
 interaction:
   agent:
-    max_imagination_steps: 1 # 0.1 sec
+    max_imagination_steps: 10 # 1.0 sec
     log_reward_imaginations: False
     log_reconstruction_imaginations: False
     log_imagination_trajectory: False
@@ -51,6 +51,7 @@ data_collectors:
   ppo_trajectory:
     max_len: ${python.eval:"128 + 1"} # +1 to retrieve final next value function output.
     use_embed_obs_as_observation: True
+    gamma: 0.9
 
 trainers:
   i_jepa:
@@ -59,6 +60,8 @@ trainers:
       batch_size: 32
       collate_fn:
         patch_size: ${models.patch_size}
+        mask_scale: [0.2, 0.45]
+        n_masks: 6
     minimum_new_data_count: 128
 
   forward_dynamics:
@@ -69,6 +72,7 @@ trainers:
       max_samples: 64 # Iteraction count.
     minimum_new_data_count: 128
   ppo:
+    entropy_coef: 0.1
     partial_dataloader:
       batch_size: 8
     max_epochs: 3

--- a/configs/experiment/i_jepa_mean_patch_with_videos.yaml
+++ b/configs/experiment/i_jepa_mean_patch_with_videos.yaml
@@ -1,0 +1,45 @@
+# @package _global_
+
+defaults:
+  - override /models: i_jepa_mean_patch
+  - override /trainers: bool_mask_i_jepa
+  - override /shared: default
+  - override /interaction/environment: video_folders
+  - override /interaction/agent: image_collecting
+shared:
+  image_width: 144
+  image_height: 144
+
+interaction:
+  environment:
+    observation_generator:
+      folder_frame_limits: ${python.eval:"int(10 * ${cvt_time_str:4h})"} # 10FPS, 4時間分. 6本の動画で24時間分
+      folder_paths:
+        - ${paths.data_dir}/random_observation_action_log/2024-08-26_12-55-45/io/video_recordings
+        - ${paths.data_dir}/random_observation_action_log/2024-08-26_13-00-14/io/video_recordings
+        - ${paths.data_dir}/random_observation_action_log/2024-08-26_13-04-15/io/video_recordings
+        - ${paths.data_dir}/random_observation_action_log/2024-08-26_13-08-31/io/video_recordings
+        - ${paths.data_dir}/random_observation_action_log/2024-08-27_09-28-27/io/video_recordings
+        - ${paths.data_dir}/random_observation_action_log/2024-08-27_09-31-50/io/video_recordings
+
+  observation_wrappers:
+    - _target_: ami.interactions.io_wrappers.function_wrapper.FunctionIOWrapper
+      wrap_function:
+        _target_: ami.interactions.io_wrappers.function_wrapper.normalize_tensor
+        _partial_: True
+        eps: 1e-6
+
+data_collectors:
+  image:
+    max_len: ${python.eval:"32 * ${trainers.i_jepa.partial_dataloader.batch_size}"}
+
+trainers:
+  i_jepa:
+    max_epochs: 1
+    partial_dataloader:
+      batch_size: 32
+      collate_fn:
+        patch_size: ${models.patch_size}
+    minimum_new_data_count: 128
+
+task_name: i_jepa_mean_patch_with_videos

--- a/configs/experiment/i_jepa_mean_patch_with_videos.yaml
+++ b/configs/experiment/i_jepa_mean_patch_with_videos.yaml
@@ -41,5 +41,6 @@ trainers:
       collate_fn:
         patch_size: ${models.patch_size}
     minimum_new_data_count: 128
+  i_jepa_latent_visualization_context: null # 学習時間が長くなるので無視
 
 task_name: i_jepa_mean_patch_with_videos

--- a/configs/models/i_jepa_mean_patch.yaml
+++ b/configs/models/i_jepa_mean_patch.yaml
@@ -10,7 +10,7 @@ patch_size: 12
 
 i_jepa_encoder:
   embed_dim: 648
-  out_dim: ${.embed_dim}
+  out_dim: 512
   depth: 12
   num_heads: 9
   mlp_ratio: 4.0

--- a/configs/models/i_jepa_mean_patch.yaml
+++ b/configs/models/i_jepa_mean_patch.yaml
@@ -1,0 +1,30 @@
+# Instantiation version 2
+
+_target_: ami.models.instantiations.i_jepa_mean_patch
+device: ${devices.0}
+img_size:
+  - ${shared.image_height}
+  - ${shared.image_width}
+in_channels: ${shared.image_channels}
+patch_size: 12
+
+i_jepa_encoder:
+  embed_dim: 648
+  out_dim: ${.embed_dim}
+  depth: 12
+  num_heads: 9
+  mlp_ratio: 4.0
+
+i_jepa_predictor:
+  hidden_dim: 324
+  depth: 12
+  num_heads: 4
+
+i_jepa_decoder:
+  decoder_blocks_in_and_out_channels:
+    - [512, 512]
+    - [512, 256]
+    - [256, 128]
+    - [128, 64]
+  n_res_blocks: 3
+  num_heads: 4

--- a/configs/models/i_jepa_mean_patch_small.yaml
+++ b/configs/models/i_jepa_mean_patch_small.yaml
@@ -1,0 +1,15 @@
+# Instantiation version 2
+
+defaults:
+  - i_jepa_mean_patch
+
+i_jepa_encoder:
+  embed_dim: 216
+  depth: 6
+  num_heads: 3
+  mlp_ratio: 4.0
+
+i_jepa_predictor:
+  hidden_dim: 108
+  depth: 6
+  num_heads: 2

--- a/configs/trainers/bool_mask_i_jepa.yaml
+++ b/configs/trainers/bool_mask_i_jepa.yaml
@@ -56,7 +56,24 @@ i_jepa_latent_visualization_target:
     shuffle: true
     drop_last: true
 
-  validation_dataloader: ${trainers.i_jepa_latent_visualization_context.validation_dataloader}
+  validation_dataloader:
+    _target_: torch.utils.data.DataLoader
+    batch_size: 128
+    shuffle: false
+    drop_last: false
+    dataset:
+      _target_: ami.trainers.components.vision.IntervalSamplingImageDataset
+      image_dir: ${paths.data_dir}/random_observation_action_log/validation
+      num_sample: 512
+      pre_loading: true
+      transform:
+        _target_: torchvision.transforms.v2.Compose
+        transforms:
+          - _target_: torchvision.transforms.v2.Resize
+            size:
+              - ${shared.image_height}
+              - ${shared.image_width}
+          - _target_: ami.trainers.components.vision.Standardization
 
   partial_optimizer:
     _target_: torch.optim.AdamW

--- a/scripts/i_jepa_mask_region_simulation.py
+++ b/scripts/i_jepa_mask_region_simulation.py
@@ -1,0 +1,71 @@
+import argparse
+
+import torch
+
+from ami.trainers.components.bool_i_jepa_mask_collator import (
+    BoolIJEPAMultiBlockMaskCollator,
+)
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description="Simulate mask region for BoolIJEPAMultiBlockMaskCollator")
+    parser.add_argument("--image_size", type=int, nargs=2, default=[144, 144], help="Image size (height, width)")
+    parser.add_argument("--patch_size", type=int, nargs=2, default=[12, 12], help="Patch size (height, width)")
+    parser.add_argument("--mask_scale", type=float, nargs=2, default=[0.10, 0.25], help="Mask scale range")
+    parser.add_argument("--n_masks", type=int, default=4, help="Number of mask candidates")
+    parser.add_argument("--aspect_ratio", type=float, nargs=2, default=[0.75, 1.5], help="Aspect ratio range")
+    parser.add_argument("--min_keep", type=int, default=10, help="Minimum number of patches to keep unmasked")
+    parser.add_argument("--num_samples", type=int, default=10000, help="Number of samples for simulation")
+    parser.add_argument("--seed", type=int, default=42, help="Random seed")
+    return parser.parse_args()
+
+
+def main() -> None:
+    args = parse_args()
+
+    torch.manual_seed(args.seed)
+    g = torch.Generator()
+    g.manual_seed(args.seed)
+
+    collator = BoolIJEPAMultiBlockMaskCollator(
+        input_size=args.image_size,
+        patch_size=args.patch_size,
+        mask_scale=args.mask_scale,
+        n_masks=args.n_masks,
+        aspect_ratio=args.aspect_ratio,
+        min_keep=args.min_keep,
+    )
+
+    encoder_mask_ratios = []
+    predictor_target_ratios = []
+
+    for _ in range(args.num_samples):
+        encoder_mask, predictor_target = collator.sample_masks_and_target(g)
+        encoder_mask_ratios.append(encoder_mask.float().mean().item())
+        predictor_target_ratios.append(predictor_target.float().mean().item())
+
+    avg_encoder_mask_ratio = sum(encoder_mask_ratios) / len(encoder_mask_ratios)
+    avg_predictor_target_ratio = sum(predictor_target_ratios) / len(predictor_target_ratios)
+
+    print(f"Average encoder mask region: {avg_encoder_mask_ratio:.4f}")
+    print(f"Average predictor target region: {avg_predictor_target_ratio:.4f}")
+
+    # Additional statistics
+    encoder_mask_tensor = torch.tensor(encoder_mask_ratios)
+    predictor_target_tensor = torch.tensor(predictor_target_ratios)
+
+    print(f"\nEncoder mask statistics:")
+    print(f"Min: {encoder_mask_tensor.min().item():.4f}")
+    print(f"Max: {encoder_mask_tensor.max().item():.4f}")
+    print(f"Median: {encoder_mask_tensor.median().item():.4f}")
+    print(f"Std Dev: {encoder_mask_tensor.std().item():.4f}")
+
+    print(f"\nPredictor target statistics:")
+    print(f"Min: {predictor_target_tensor.min().item():.4f}")
+    print(f"Max: {predictor_target_tensor.max().item():.4f}")
+    print(f"Median: {predictor_target_tensor.median().item():.4f}")
+    print(f"Std Dev: {predictor_target_tensor.std().item():.4f}")
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/i_jepa_mask_region_simulation.py
+++ b/scripts/i_jepa_mask_region_simulation.py
@@ -8,7 +8,9 @@ from ami.trainers.components.bool_i_jepa_mask_collator import (
 
 
 def parse_args() -> argparse.Namespace:
-    parser = argparse.ArgumentParser(description="Calculate the ratio of the masked regions output from BoolIJEPAMultiBlockMaskCollator by simulation.")
+    parser = argparse.ArgumentParser(
+        description="Calculate the ratio of the masked regions output from BoolIJEPAMultiBlockMaskCollator by simulation."
+    )
     parser.add_argument("--image_size", type=int, nargs=2, default=[144, 144], help="Image size (height, width)")
     parser.add_argument("--patch_size", type=int, nargs=2, default=[12, 12], help="Patch size (height, width)")
     parser.add_argument("--mask_scale", type=float, nargs=2, default=[0.10, 0.25], help="Mask scale range")

--- a/scripts/i_jepa_mask_region_simulation.py
+++ b/scripts/i_jepa_mask_region_simulation.py
@@ -54,13 +54,13 @@ def main() -> None:
     encoder_mask_tensor = torch.tensor(encoder_mask_ratios)
     predictor_target_tensor = torch.tensor(predictor_target_ratios)
 
-    print(f"\nEncoder mask statistics:")
+    print("\nEncoder mask statistics:")
     print(f"Min: {encoder_mask_tensor.min().item():.4f}")
     print(f"Max: {encoder_mask_tensor.max().item():.4f}")
     print(f"Median: {encoder_mask_tensor.median().item():.4f}")
     print(f"Std Dev: {encoder_mask_tensor.std().item():.4f}")
 
-    print(f"\nPredictor target statistics:")
+    print("\nPredictor target statistics:")
     print(f"Min: {predictor_target_tensor.min().item():.4f}")
     print(f"Max: {predictor_target_tensor.max().item():.4f}")
     print(f"Median: {predictor_target_tensor.median().item():.4f}")

--- a/scripts/i_jepa_mask_region_simulation.py
+++ b/scripts/i_jepa_mask_region_simulation.py
@@ -8,7 +8,7 @@ from ami.trainers.components.bool_i_jepa_mask_collator import (
 
 
 def parse_args() -> argparse.Namespace:
-    parser = argparse.ArgumentParser(description="Simulate mask region for BoolIJEPAMultiBlockMaskCollator")
+    parser = argparse.ArgumentParser(description="Calculate the ratio of the masked regions output from BoolIJEPAMultiBlockMaskCollator by simulation.")
     parser.add_argument("--image_size", type=int, nargs=2, default=[144, 144], help="Image size (height, width)")
     parser.add_argument("--patch_size", type=int, nargs=2, default=[12, 12], help="Patch size (height, width)")
     parser.add_argument("--mask_scale", type=float, nargs=2, default=[0.10, 0.25], help="Mask scale range")

--- a/tests/models/test_i_jepa_latent_visualization_decoder.py
+++ b/tests/models/test_i_jepa_latent_visualization_decoder.py
@@ -7,6 +7,7 @@ import torch
 from ami.models.i_jepa_latent_visualization_decoder import (
     DecoderBlock,
     IJEPALatentVisualizationDecoder,
+    IJEPAMeanLatentAlongPatchVisualizationDecoder,
     ResBlock,
 )
 
@@ -122,3 +123,22 @@ class TestIJEPALatentVisualizationDecoder:
         expected_height = input_n_patches_height * magnification
         expected_width = input_n_patches_width * magnification
         assert out_images.size() == (batch_size, 3, expected_height, expected_width)
+
+
+class TestIJEPAMeanLatentAlongPatchVisualizationDecoder:
+    @pytest.mark.parametrize("batch_shape", [(), (8,)])
+    @pytest.mark.parametrize("latent_dim", [64, 32])
+    def test_forward(self, batch_shape, latent_dim):
+        decoder = IJEPAMeanLatentAlongPatchVisualizationDecoder(
+            input_n_patches=8,
+            input_latents_dim=latent_dim,
+            decoder_blocks_in_and_out_channels=[(128, 128), (128, 96), (96, 64), (64, 32)],
+            n_res_blocks=1,
+            num_heads=4,
+        )
+
+        x = torch.randn(*batch_shape, latent_dim)
+
+        out = decoder.forward(x)
+        image_size = 8 * 2**3
+        assert out.shape == (*batch_shape, 3, image_size, image_size)

--- a/tests/models/test_instantiations.py
+++ b/tests/models/test_instantiations.py
@@ -2,6 +2,7 @@ from typing import Any, Callable, get_type_hints
 
 from ami.models.instantiations import (
     InstantiationReturnType,
+    i_jepa_mean_patch,
     i_jepa_mean_patch_sioconv_resnetpolicy,
     image_vae,
 )
@@ -37,3 +38,8 @@ def test_image_vae():
 def test_i_jepa_mean_patch_sioconv_resnetpolicy():
     assert_return_type_annotation(i_jepa_mean_patch_sioconv_resnetpolicy)
     assert_return_type(i_jepa_mean_patch_sioconv_resnetpolicy())
+
+
+def test_i_jepa_mean_patch():
+    assert_return_type_annotation(i_jepa_mean_patch)
+    assert_return_type(i_jepa_mean_patch())

--- a/tests/test_configs.py
+++ b/tests/test_configs.py
@@ -37,6 +37,7 @@ if not (DATA_DIR / "random_observation_action_log").exists():
     IGNORE_EXPERIMENT_CONFIGS.add("bool_mask_i_jepa_with_videos.yaml")
     IGNORE_EXPERIMENT_CONFIGS.add("learn_only_sioconv.yaml")
     IGNORE_EXPERIMENT_CONFIGS.add("learn_i_jepa_sioconv.yaml")
+    IGNORE_EXPERIMENT_CONFIGS.add("i_jepa_mean_patch_with_videos.yaml")
 
 if not (DATA_DIR / "2024-09-14_09-42-23,678417.ckpt").exists():
     IGNORE_EXPERIMENT_CONFIGS.add("learn_only_sioconv.yaml")


### PR DESCRIPTION
## 概要

#157

## 変更内容

* I-JEPA単体で学習する際の実装や学習設定ファイルを追加
  * Decoderを新規に実装
  * infer関数を新規に実装
  * Visualization Trainerの学習に時間がかかるようになってしまったため、Context EncoderのVisualizationを無視
  * Trainerに`null`を設定可能にし、その場合は無視するようにインスタンス化処理を変更
* 実際にどれだけマスクされるかその割合をシミュレートするスクリプトファイルを実装
* ぱみきゅーが探索的に行動する設定に変更

## 影響範囲

<!-- この関数を変更したのでこの機能にも影響がある、など -->

## Submit前の確認項目

<!-- PRをSubmitする前に確認する項目 -->

- [ ] タイトルは一目でわかるようにし、説明文は PR を簡潔に説明するようにしましたか?
- [ ] あなたの PR が、異なる変更を束ねたものではなく、ひとつのことだけを行うものであることを確認しましたか?
- [ ] この PR で導入されたすべての変更点をリストアップしましたか?
- [ ] PR を`make run`コマンドでローカルでテストしましたか?

## 補足

<!-- レビューをする際に見てほしい点、ローカル環境で試す際の注意点、など -->
