### PR TITLE
VRChatOSCDiscreteActuatorを移動や回転速度を設定可能に

### DIFF
--- a/ami/interactions/environments/actuators/vrchat_osc_discrete_actuator.py
+++ b/ami/interactions/environments/actuators/vrchat_osc_discrete_actuator.py
@@ -39,7 +39,7 @@ class VRChatOSCDiscreteActuator(BaseActuator[torch.Tensor]):
         osc_sender_port: int = 9000,
         move_vertical_velocity: float = 1.0,
         move_horizontal_velocity: float = 1.0,
-        look_horizontal_velocity: float = 1.0,
+        look_horizontal_velocity: float = 1.0,  # > 0.5 to move.
     ) -> None:
         """Create VRChatOSCDiscreteActuator object.
 

--- a/configs/interaction/environment/vrchat_image_discrete.yaml
+++ b/configs/interaction/environment/vrchat_image_discrete.yaml
@@ -11,3 +11,6 @@ actuator:
   _target_: ami.interactions.environments.actuators.vrchat_osc_discrete_actuator.VRChatOSCDiscreteActuator
   osc_address: "127.0.0.1"
   osc_sender_port: 9000
+  move_vertical_velocity: 1.0
+  move_horizontal_velocity: 1.0
+  look_horizontal_velocity: 1.0


### PR DESCRIPTION
## 概要

VRChatOSCDiscreteActuatorを移動や回転速度を設定可能にしました。
ぱみきゅーがグルグル回る行動に収束する現象を調べるためにこの実装を行いました。回転方向の視覚変化の変化率を小さくし、ぱみきゅーが前後左右の移動に収束するようになるのかを調べます。

## 変更内容

## 影響範囲

<!-- この関数を変更したのでこの機能にも影響がある、など -->

## Submit前の確認項目

<!-- PRをSubmitする前に確認する項目 -->

- [ ] タイトルは一目でわかるようにし、説明文は PR を簡潔に説明するようにしましたか?
- [ ] あなたの PR が、異なる変更を束ねたものではなく、ひとつのことだけを行うものであることを確認しましたか?
- [ ] この PR で導入されたすべての変更点をリストアップしましたか?
- [ ] PR を`make run`コマンドでローカルでテストしましたか?

## 補足

<!-- レビューをする際に見てほしい点、ローカル環境で試す際の注意点、など -->
