### PR TITLE
一次遅れ系ステップ応答をシミュレートしたDiscreteActuatorを実装

### DIFF
--- a/ami/interactions/environments/actuators/first_order_delay_system.py
+++ b/ami/interactions/environments/actuators/first_order_delay_system.py
@@ -1,0 +1,98 @@
+import math
+
+
+class FirstOrderDelaySystemStepResponce:
+    """A first-order delay system step response simulator.
+
+    This class implements a first-order delay system that gradually approaches
+    a target value according to the following differential equation:
+        τ * (dy/dt) + y = Ku
+    where:
+        τ: time constant
+        y: output value
+        K: system gain (assumed to be 1.0)
+        u: input value (target value)
+
+    The system response follows an exponential curve:
+        y(t) = y_0 + (u - y_0)(1 - e^(-t/τ))
+    where:
+        y_0: initial value
+        u: target value
+        t: elapsed time
+        τ: time constant
+
+    Usage:
+        # Create a system with 0.1s time step and 0.5s time constant
+        system = FirstOrderDelaySystemStepResponce(
+            delta_time=0.1,
+            time_constant=0.5,
+            initial_value=0.0
+        )
+
+        # Set target to 1.0 and simulate for 2 seconds
+        system.set_target_value(1.0)
+        for _ in range(20):  # 20 steps * 0.1s = 2s
+            current_value = system.step()
+            print(f"Current value: {current_value}")
+    """
+
+    def __init__(self, delta_time: float, time_constant: float, initial_value: float = 0.0) -> None:
+        """Initialize the first-order delay system.
+
+        Args:
+            delta_time: Time step for numerical integration in seconds.
+                Must be positive.
+            time_constant: Time constant (τ) of the system in seconds.
+                Must be positive. Larger values result in slower response.
+            initial_value: Initial output value of the system.
+                Defaults to 0.0.
+
+        Raises:
+            AssertionError: If delta_time or time_constant is not positive.
+        """
+        assert delta_time > 0
+        assert time_constant > 0
+
+        self.delta_time = delta_time
+        self.time_constant = time_constant
+
+        self._start_value = initial_value
+        self._target_value = initial_value
+        self._current_value = 0.0
+        self._current_elapsed_time = 0.0
+
+    def set_target_value(self, value: float) -> None:
+        """Set a new target value for the system.
+
+        When the target value changes, the system response will start
+        from the current value and exponentially approach the new target.
+        The elapsed time counter is reset to ensure proper exponential behavior.
+
+        Args:
+            value: New target value for the system to approach.
+        """
+        if self._target_value != value:
+            self._start_value = self._current_value
+            self._current_elapsed_time = 0.0
+
+        self._target_value = value
+
+    def step(self) -> float:
+        """Step the simulation forward by one time step.
+
+        Updates the system state using numerical integration of the
+        first-order differential equation. The integration uses the
+        analytical solution of the exponential decay to maintain accuracy.
+
+        Returns:
+            float: Current output value of the system after the time step.
+        """
+        self._current_elapsed_time += self.delta_time
+        delta_value = (
+            (self._target_value - self._start_value)
+            / self.time_constant
+            * math.exp(-self._current_elapsed_time / self.time_constant)
+            * self.delta_time
+        )
+        self._current_value += delta_value
+        return self._current_value

--- a/ami/interactions/environments/actuators/first_order_delay_system.py
+++ b/ami/interactions/environments/actuators/first_order_delay_system.py
@@ -15,9 +15,9 @@ class FirstOrderDelaySystemStepResponce:
 
     The system response is computed using the analytical solution
     for the step response of a first-order system:
-        y(t) = y₀ + (u - y₀)(1 - e^(-t/τ))
+        y(t) = y_0 + (u - y_0)(1 - e^(-t/τ))
     where:
-        y₀: initial value at the start of the current transition
+        y_0: initial value at the start of the current transition
         u: target value
         t: elapsed time since the last target value change
         τ: time constant
@@ -89,7 +89,7 @@ class FirstOrderDelaySystemStepResponce:
 
         Calculates the current value using the analytical solution
         of the first-order differential equation:
-            y(t) = y₀ + (u - y₀)(1 - e^(-t/τ))
+            y(t) = y_0 + (u - y_0)(1 - e^(-t/τ))
 
         Returns:
             float: Current output value of the system.

--- a/ami/interactions/environments/actuators/vrchat_osc_discrete_actuator.py
+++ b/ami/interactions/environments/actuators/vrchat_osc_discrete_actuator.py
@@ -241,6 +241,9 @@ class FirstOrderDelaySystemDiscreteActuator(BaseActuator[torch.Tensor]):
         command = self.convert_action_to_command(action.long().tolist())
         self.controller.command(command)
         self._previous_action = action
+        self._move_vertical_system.step()
+        self._move_horizontal_system.step()
+        self._look_horizontal_system.step()
 
     def setup(self) -> None:
         """Setup the actuator."""
@@ -281,7 +284,7 @@ class FirstOrderDelaySystemDiscreteActuator(BaseActuator[torch.Tensor]):
                 self._move_vertical_system.set_target_value(-self.max_move_vertical_velocity)
             case _:
                 raise ValueError(f"Action choices are 0 to 2! Input: {move_vert}")
-        return {Axes.Vertical: self._move_vertical_system.step()}
+        return {Axes.Vertical: self._move_vertical_system.get_current_value()}
 
     def move_horizontal_to_command(self, move_horzn: int) -> dict[str, float]:
         match move_horzn:
@@ -293,7 +296,7 @@ class FirstOrderDelaySystemDiscreteActuator(BaseActuator[torch.Tensor]):
                 self._move_horizontal_system.set_target_value(-self.max_move_horizontal_velocity)
             case _:
                 raise ValueError(f"Action choices are 0 to 2! Input: {move_horzn}")
-        return {Axes.Horizontal: self._move_horizontal_system.step()}
+        return {Axes.Horizontal: self._move_horizontal_system.get_current_value()}
 
     def look_horizontal_to_command(self, look_horzn: int) -> dict[str, float]:
         match look_horzn:
@@ -305,7 +308,7 @@ class FirstOrderDelaySystemDiscreteActuator(BaseActuator[torch.Tensor]):
                 self._look_horizontal_system.set_target_value(-self.max_look_horizontal_velocity)
             case _:
                 raise ValueError(f"Choices are 0 to 2! Input: {look_horzn}")
-        return {Axes.LookHorizontal: self._look_horizontal_system.step()}
+        return {Axes.LookHorizontal: self._look_horizontal_system.get_current_value()}
 
     @staticmethod
     def jump_to_command(jump: int) -> dict[str, int]:

--- a/ami/interactions/environments/actuators/vrchat_osc_discrete_actuator.py
+++ b/ami/interactions/environments/actuators/vrchat_osc_discrete_actuator.py
@@ -6,6 +6,7 @@ from vrchat_io.controller.osc import RESET_VALUES, Axes, Buttons, InputControlle
 from vrchat_io.controller.wrappers.osc import MultiInputWrapper
 
 from .base_actuator import BaseActuator
+from .first_order_delay_system import FirstOrderDelaySystemStepResponce
 
 ACTION_CHOICES_PER_CATEGORY = [3, 3, 3, 2, 2]
 ACTION_CHOICES_PER_CATEGORY_MASKED_JUMP_RUN = [3, 3, 3, 1, 1]  # 去年のAMIと行動設定を合わせるため。
@@ -129,6 +130,182 @@ class VRChatOSCDiscreteActuator(BaseActuator[torch.Tensor]):
                 return {Axes.LookHorizontal: -self.look_horizontal_velocity}
             case _:
                 raise ValueError(f"Choices are 0 to 2! Input: {look_horzn}")
+
+    @staticmethod
+    def jump_to_command(jump: int) -> dict[str, int]:
+        match jump:
+            case 0:
+                return {Buttons.Jump: 0}
+            case 1:
+                return {Buttons.Jump: 1}
+            case _:
+                raise ValueError(f"Choices are 0 or 1! Input: {jump}")
+
+    @staticmethod
+    def run_to_command(run: int) -> dict[str, int]:
+        match run:
+            case 0:
+                return {Buttons.Run: 0}
+            case 1:
+                return {Buttons.Run: 1}
+            case _:
+                raise ValueError(f"Choices are 0 or 1! Input: {run}")
+
+
+class FirstOrderDelaySystemDiscreteActuator(BaseActuator[torch.Tensor]):
+    """Treats discrete actions for VRChat OSC with first-order delay system
+    dynamics.
+
+    This actuator provides smooth acceleration and deceleration for continuous
+    movements (vertical, horizontal, and look) by applying first-order delay
+    system dynamics. Each continuous action gradually approaches its target
+    velocity according to the specified time constant.
+
+    Actions:
+        MoveVertical: [0: stop | 1: forward | 2: backward]
+            - Smoothly approaches target velocity
+            - Forward: +max_move_vertical_velocity
+            - Backward: -max_move_vertical_velocity
+            - Stop: 0.0
+
+        MoveHorizontal: [0: stop | 1: right | 2: left]
+            - Smoothly approaches target velocity
+            - Right: +max_move_horizontal_velocity
+            - Left: -max_move_horizontal_velocity
+            - Stop: 0.0
+
+        LookHorizontal: [0: stop | 1: right | 2: left]
+            - Smoothly approaches target velocity
+            - Right: +max_look_horizontal_velocity
+            - Left: -max_look_horizontal_velocity
+            - Stop: 0.0
+
+        Jump: [0: release | 1: do]
+            - Discrete action (no smoothing)
+
+        Run: [0: release | 1: do]
+            - Discrete action (no smoothing)
+
+    The continuous actions (Move/Look) use first-order delay dynamics:
+        τ(dy/dt) + y = u
+    where:
+        τ: time constant
+        y: current velocity
+        u: target velocity
+    """
+
+    def __init__(
+        self,
+        osc_address: str = "127.0.0.1",
+        osc_sender_port: int = 9000,
+        max_move_vertical_velocity: float = 1.0,
+        max_move_horizontal_velocity: float = 1.0,
+        max_look_horizontal_velocity: float = 1.0,  # > 0.5 to move.
+        delta_time: float = 0.1,  # seconds
+        time_constant: float = 0.5,  # second
+    ) -> None:
+        """Create FirstOrderDelaySystemDiscreteActuator object.
+
+        Args:
+            osc_address: IP address of OSC server.
+            osc_sender_port: Port number of OSC server.
+            max_move_vertical_velocity: Maximum velocity for moving forward/backward.
+            max_move_horizontal_velocity: Maximum velocity for moving left/right.
+            max_look_horizontal_velocity: Maximum velocity for turning left/right.
+            delta_time: Time step for numerical integration in seconds.
+                Controls how often the velocity updates are calculated.
+            time_constant: Time constant for the first-order delay system in seconds.
+                Larger values result in slower acceleration/deceleration.
+                For example:
+                - 0.5s: Reaches ~63% of target velocity in 0.5s
+                - 1.0s: Reaches ~63% of target velocity in 1.0s
+        """
+        controller = InputController((osc_address, osc_sender_port))
+        self.controller = MultiInputWrapper(controller)
+        self._previous_action = STOP_ACTION.clone()
+
+        self.max_move_vertical_velocity = max_move_vertical_velocity
+        self.max_move_horizontal_velocity = max_move_horizontal_velocity
+        self.max_look_horizontal_velocity = max_look_horizontal_velocity
+
+        self._move_vertical_system = FirstOrderDelaySystemStepResponce(delta_time, time_constant, 0.0)
+        self._move_horizontal_system = FirstOrderDelaySystemStepResponce(delta_time, time_constant, 0.0)
+        self._look_horizontal_system = FirstOrderDelaySystemStepResponce(delta_time, time_constant, 0.0)
+
+    def operate(self, action: torch.Tensor) -> None:
+        """Operate the actuator with the given action.
+
+        Args:
+            action: The command for actuator as a `Tensor`.
+        """
+        command = self.convert_action_to_command(action.long().tolist())
+        self.controller.command(command)
+        self._previous_action = action
+
+    def setup(self) -> None:
+        """Setup the actuator."""
+        self.controller.command(RESET_VALUES)
+
+    def teardown(self) -> None:
+        """Teardown the actuator."""
+        self.controller.command(RESET_VALUES)
+
+    _action_before_on_paused: torch.Tensor  # set in `on_paused`
+
+    @override
+    def on_paused(self) -> None:
+        self._action_before_on_paused = self._previous_action.clone()
+        self.operate(STOP_ACTION)
+
+    @override
+    def on_resumed(self) -> None:
+        self.operate(self._action_before_on_paused)
+
+    def convert_action_to_command(self, action: list[int]) -> dict[str, Any]:
+        """Convert raw action list to command dictionary."""
+        command = {}
+        command.update(self.move_vertical_to_command(action[0]))
+        command.update(self.move_horizontal_to_command(action[1]))
+        command.update(self.look_horizontal_to_command(action[2]))
+        command.update(self.jump_to_command(action[3]))
+        command.update(self.run_to_command(action[4]))
+        return command
+
+    def move_vertical_to_command(self, move_vert: int) -> dict[str, float]:
+        match move_vert:
+            case 0:  # stop
+                self._move_vertical_system.set_target_value(0.0)
+            case 1:  # forward
+                self._move_vertical_system.set_target_value(self.max_move_vertical_velocity)
+            case 2:  # backward
+                self._move_vertical_system.set_target_value(-self.max_move_vertical_velocity)
+            case _:
+                raise ValueError(f"Action choices are 0 to 2! Input: {move_vert}")
+        return {Axes.Vertical: self._move_vertical_system.step()}
+
+    def move_horizontal_to_command(self, move_horzn: int) -> dict[str, float]:
+        match move_horzn:
+            case 0:  # stop
+                self._move_horizontal_system.set_target_value(0.0)
+            case 1:  # forward
+                self._move_horizontal_system.set_target_value(self.max_move_horizontal_velocity)
+            case 2:  # backward
+                self._move_horizontal_system.set_target_value(-self.max_move_horizontal_velocity)
+            case _:
+                raise ValueError(f"Action choices are 0 to 2! Input: {move_horzn}")
+        return {Axes.Horizontal: self._move_horizontal_system.step()}
+
+    def look_horizontal_to_command(self, look_horzn: int) -> dict[str, float]:
+        match look_horzn:
+            case 0:  # stop
+                self._look_horizontal_system.set_target_value(0.0)
+            case 1:
+                self._look_horizontal_system.set_target_value(self.max_look_horizontal_velocity)
+            case 2:
+                self._look_horizontal_system.set_target_value(-self.max_look_horizontal_velocity)
+            case _:
+                raise ValueError(f"Choices are 0 to 2! Input: {look_horzn}")
+        return {Axes.LookHorizontal: self._look_horizontal_system.step()}
 
     @staticmethod
     def jump_to_command(jump: int) -> dict[str, int]:

--- a/configs/interaction/environment/vrchat_image_discrete_1st_order_delay.yaml
+++ b/configs/interaction/environment/vrchat_image_discrete_1st_order_delay.yaml
@@ -1,0 +1,18 @@
+_target_: ami.interactions.environments.sensor_actuator_env.SensorActuatorEnv
+
+sensor:
+  _target_: ami.interactions.environments.sensors.opencv_image_sensor.OpenCVImageSensor
+  camera_index: 0
+  width: ${shared.image_width}
+  height: ${shared.image_height}
+  base_fps: 60
+
+actuator:
+  _target_: ami.interactions.environments.actuators.vrchat_osc_discrete_actuator.FirstOrderDelaySystemDiscreteActuator
+  osc_address: "127.0.0.1"
+  osc_sender_port: 9000
+  max_move_vertical_velocity: 1.0
+  max_move_horizontal_velocity: 1.0
+  max_look_horizontal_velocity: 1.0
+  delta_time: 1.0
+  time_constant: 0.2

--- a/samples/first_order_delay_system_discrete_actuator_demo.py
+++ b/samples/first_order_delay_system_discrete_actuator_demo.py
@@ -30,7 +30,7 @@ NOTE: Linux User
     Because keyboard module requires root user to access keyboard device.
     So run the following command in the project root directory.
     ```sh
-    PYTHON_PATH=$(which python3) && sudo $PYTHON_PATH ./scripts/first_order_delay_system_discrete_actuator_demo.py
+    PYTHON_PATH=$(which python3) && sudo $PYTHON_PATH ./samples/first_order_delay_system_discrete_actuator_demo.py
     ```
 
 Features:

--- a/samples/first_order_delay_system_discrete_actuator_demo.py
+++ b/samples/first_order_delay_system_discrete_actuator_demo.py
@@ -1,0 +1,186 @@
+"""First Order Delay System Demo.
+
+This script demonstrates keyboard control with FirstOrderDelaySystemDiscreteActuator,
+which provides smooth acceleration and deceleration for continuous movements.
+
+Additional Dependency:
+    pip install keyboard
+
+Usage:
+    python first_order_delay_system_discrete_actuator_demo.py [--osc-ip OSC_IP] [--osc-port OSC_PORT]
+        [--time-constant TIME_CONSTANT] [--delta-time DELTA_TIME] [--max-velocity MAX_VELOCITY]
+
+    Optional arguments:
+    --osc-ip OSC_IP           IP address for OSC server (default: 127.0.0.1)
+    --osc-port OSC_PORT       Port number for OSC server (default: 9000)
+    --time-constant TIME_CONST Time constant for delay system in seconds (default: 0.5)
+    --delta-time DELTA_TIME   Update interval in seconds (default: 0.1)
+    --max-velocity MAX_VEL    Maximum velocity for all movements (default: 1.0)
+
+Controls:
+    - W/S: Move forward/backward
+    - A/D: Move left/right
+    - ,/.: Turn left/right
+    - Space: Jump
+    - Shift: Run
+    - Q: Quit
+
+NOTE: Linux User
+    You need to run this script as root user.
+    Because keyboard module requires root user to access keyboard device.
+    So run the following command in the project root directory.
+    ```sh
+    PYTHON_PATH=$(which python3) && sudo $PYTHON_PATH ./scripts/first_order_delay_system_discrete_actuator_demo.py
+    ```
+
+Features:
+    - Smooth acceleration and deceleration for all continuous movements
+    - Configurable time constant affects how quickly movements reach target velocity
+    - Real-time keyboard control with immediate response
+"""
+
+import argparse
+import sys
+import time
+
+import keyboard
+import torch
+
+from ami.interactions.environments.actuators.vrchat_osc_discrete_actuator import (
+    FirstOrderDelaySystemDiscreteActuator,
+)
+
+
+class KeyboardActionHandler:
+    """Handles keyboard input and converts it to discrete actions."""
+
+    def __init__(self) -> None:
+        """Initialize the keyboard action handler."""
+        self.initial_actions = torch.zeros(5, dtype=torch.long)  # [vertical, horizontal, look, jump, run]
+        self.actions = self.initial_actions.clone()
+
+        self.key_map = {  # (action_index, value)
+            "w": (0, 1),  # vertical forward
+            "s": (0, 2),  # vertical backward
+            "d": (1, 1),  # horizontal right
+            "a": (1, 2),  # horizontal left
+            ".": (2, 1),  # look right
+            ",": (2, 2),  # look left
+            "space": (3, 1),  # jump
+            "shift": (4, 1),  # run
+        }
+
+    def update(self) -> bool:
+        """Update action state based on current keyboard input.
+
+        Returns:
+            bool: False if quit is requested (Q pressed), True otherwise
+        """
+        self.actions = self.initial_actions.clone()
+
+        for key, (action_idx, value) in self.key_map.items():
+            if keyboard.is_pressed(key):
+                self.actions[action_idx] = value
+
+        return not keyboard.is_pressed("q")  # Return False if 'q' is pressed to quit
+
+    def get_actions(self) -> torch.Tensor:
+        """Get current action state.
+
+        Returns:
+            torch.Tensor: Current action state
+        """
+        return self.actions.clone()
+
+
+def parse_arguments() -> argparse.Namespace:
+    """Parse command line arguments.
+
+    Returns:
+        argparse.Namespace: Parsed command line arguments
+    """
+    parser = argparse.ArgumentParser(description="First Order Delay System Demo")
+    parser.add_argument("--osc-ip", type=str, default="127.0.0.1", help="IP address for OSC server")
+    parser.add_argument("--osc-port", type=int, default=9000, help="Port number for OSC server")
+    parser.add_argument("--time-constant", type=float, default=0.5, help="Time constant for delay system in seconds")
+    parser.add_argument("--delta-time", type=float, default=0.1, help="Update interval in seconds")
+    parser.add_argument("--max-velocity", type=float, default=1.0, help="Maximum velocity for all movements")
+    return parser.parse_args()
+
+
+def print_status(actions: torch.Tensor, clear: bool = True) -> None:
+    """Print current action state to console.
+
+    Args:
+        actions: Current action tensor
+        clear: Whether to clear the line before printing
+    """
+    status = [
+        "↑" if actions[0] == 1 else "↓" if actions[0] == 2 else "-",  # vertical
+        "→" if actions[1] == 1 else "←" if actions[1] == 2 else "-",  # horizontal
+        "»" if actions[2] == 1 else "«" if actions[2] == 2 else "-",  # look
+        "⋀" if actions[3] == 1 else "-",  # jump
+        "⚡" if actions[4] == 1 else "-",  # run
+    ]
+    print(f"\r[{' '.join(status)}]", end="", flush=True)
+
+
+def main() -> None:
+    """Main function for the demo script."""
+    args = parse_arguments()
+
+    # Initialize components
+    action_handler = KeyboardActionHandler()
+    actuator = FirstOrderDelaySystemDiscreteActuator(
+        osc_address=args.osc_ip,
+        osc_sender_port=args.osc_port,
+        max_move_vertical_velocity=args.max_velocity,
+        max_move_horizontal_velocity=args.max_velocity,
+        max_look_horizontal_velocity=args.max_velocity,
+        delta_time=args.delta_time,
+        time_constant=args.time_constant,
+    )
+
+    # Setup actuator
+    try:
+        actuator.setup()
+        print("Demo started with:")
+        print(f"- Time constant: {args.time_constant}s")
+        print(f"- Update interval: {args.delta_time}s")
+        print(f"- Max velocity: {args.max_velocity}")
+        print("Use WASD, <>, Space, Shift to control. Press Q to quit.")
+        print("\nCurrent state:")
+
+        # Main loop
+        next_update_time = time.time()
+        while True:
+            current_time = time.time()
+
+            if current_time >= next_update_time:
+                # Update and apply actions
+                if not action_handler.update():
+                    break
+
+                actions = action_handler.get_actions()
+                actuator.operate(actions)
+                print_status(actions)
+
+                # Schedule next update
+                next_update_time += args.delta_time
+
+            # Small sleep to prevent CPU overload
+            time.sleep(max(0, next_update_time - time.time()))
+
+    except KeyboardInterrupt:
+        print("\nInterrupted by user")
+    except Exception as e:
+        print(f"\nError occurred: {e}", file=sys.stderr)
+        raise
+    finally:
+        # Cleanup
+        actuator.teardown()
+        print("\nDemo finished.")
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/interactions/environments/actuators/test_first_order_delay_system.py
+++ b/tests/interactions/environments/actuators/test_first_order_delay_system.py
@@ -1,0 +1,81 @@
+import math
+
+import pytest
+
+from ami.interactions.environments.actuators.first_order_delay_system import (
+    FirstOrderDelaySystemStepResponce,
+)
+
+
+class TestFirstOrderDelaySystemStepResponce:
+    @pytest.fixture
+    def system(self):
+        """Create a default system for testing with standard parameters."""
+        return FirstOrderDelaySystemStepResponce(delta_time=0.1, time_constant=0.5, initial_value=0.0)
+
+    def test_invalid_parameters(self):
+        """Test that invalid parameters raise appropriate errors."""
+        with pytest.raises(AssertionError):
+            FirstOrderDelaySystemStepResponce(delta_time=-0.1, time_constant=0.5)
+
+        with pytest.raises(AssertionError):
+            FirstOrderDelaySystemStepResponce(delta_time=0.1, time_constant=-0.5)
+
+    def test_set_target_value(self, system: FirstOrderDelaySystemStepResponce):
+        """Test setting target values and verifying state changes."""
+        # Initial state
+        assert system._target_value == 0.0
+        assert system._current_elapsed_time == 0.0
+
+        # Set new target
+        system.set_target_value(1.0)
+        assert system._target_value == 1.0
+        assert system._current_elapsed_time == 0.0
+        assert system._start_value == system._current_value
+
+        # Set same target (shouldn't reset elapsed time)
+        system._current_elapsed_time = 0.5
+        system.set_target_value(1.0)
+        assert system._current_elapsed_time == 0.5
+
+        # Set different target (should reset elapsed time)
+        system.set_target_value(2.0)
+        assert system._current_elapsed_time == 0.0
+
+    def test_step_response(self, system: FirstOrderDelaySystemStepResponce):
+        """Test the step response behavior of the system."""
+        # Set target to 1.0
+        system.set_target_value(1.0)
+
+        # Step through simulation and verify response
+        values = []
+        for _ in range(10):  # Simulate for 1 second (10 * 0.1s)
+            value = system.step()
+            values.append(value)
+
+        # Verify that values are monotonically increasing
+        assert all(values[i] <= values[i + 1] for i in range(len(values) - 1))
+
+        # Verify final value is approaching target
+        assert values[-1] == pytest.approx(1.0, rel=0.3)  # Should be close to 1.0 but not quite there
+
+    def test_multiple_target_changes(self, system: FirstOrderDelaySystemStepResponce):
+        """Test system response to multiple target value changes."""
+        # First target
+        system.set_target_value(1.0)
+        values1 = [system.step() for _ in range(5)]
+
+        # Change target midway
+        system.set_target_value(-1.0)
+        values2 = [system.step() for _ in range(5)]
+
+        # Verify direction changes
+        assert all(values1[i] <= values1[i + 1] for i in range(len(values1) - 1))  # Increasing
+        assert all(values2[i] >= values2[i + 1] for i in range(len(values2) - 1))  # Decreasing
+
+    def test_zero_response(self, system: FirstOrderDelaySystemStepResponce):
+        """Test system response when target equals initial value."""
+        system.set_target_value(0.0)  # Same as initial value
+        for _ in range(10):
+            value = system.step()
+            assert value == pytest.approx(0.0, abs=1e-10)

--- a/tests/interactions/environments/actuators/test_first_order_delay_system.py
+++ b/tests/interactions/environments/actuators/test_first_order_delay_system.py
@@ -21,61 +21,79 @@ class TestFirstOrderDelaySystemStepResponce:
         with pytest.raises(AssertionError):
             FirstOrderDelaySystemStepResponce(delta_time=0.1, time_constant=-0.5)
 
-    def test_set_target_value(self, system: FirstOrderDelaySystemStepResponce):
-        """Test setting target values and verifying state changes."""
-        # Initial state
+    def test_initial_state(self, system: FirstOrderDelaySystemStepResponce):
+        """Test the initial state of the system."""
         assert system._target_value == 0.0
         assert system._current_elapsed_time == 0.0
+        assert system._start_value == 0.0
+        assert system.get_current_value() == 0.0
+
+    def test_set_target_value(self, system: FirstOrderDelaySystemStepResponce):
+        """Test setting target values and verifying state changes."""
+        # Step a few times to get a non-zero current value
+        system.set_target_value(1.0)
+        for _ in range(3):
+            system.step()
+        current_value = system.get_current_value()
 
         # Set new target
-        system.set_target_value(1.0)
-        assert system._target_value == 1.0
+        system.set_target_value(2.0)
+        assert system._target_value == 2.0
         assert system._current_elapsed_time == 0.0
-        assert system._start_value == system._current_value
+        assert system._start_value == current_value
 
         # Set same target (shouldn't reset elapsed time)
         system._current_elapsed_time = 0.5
-        system.set_target_value(1.0)
+        system.set_target_value(2.0)
         assert system._current_elapsed_time == 0.5
 
-        # Set different target (should reset elapsed time)
-        system.set_target_value(2.0)
-        assert system._current_elapsed_time == 0.0
+    @pytest.mark.parametrize(
+        "time_point,expected_percentage",
+        [
+            # t = τ, 2τ, 3τ
+            (0.5, 0.632),
+            (1.0, 0.865),
+            (1.5, 0.950),
+        ],
+    )
+    def test_analytical_response(self, system: FirstOrderDelaySystemStepResponce, time_point, expected_percentage):
+        """Test that the system follows the analytical solution."""
+        target_value = 1.0
+        system.set_target_value(target_value)
 
-    def test_step_response(self, system: FirstOrderDelaySystemStepResponce):
-        """Test the step response behavior of the system."""
-        # Set target to 1.0
-        system.set_target_value(1.0)
-
-        # Step through simulation and verify response
-        values = []
-        for _ in range(10):  # Simulate for 1 second (10 * 0.1s)
+        # Step until we reach the desired time
+        steps_needed = int(time_point / system.delta_time)
+        for _ in range(steps_needed):
             value = system.step()
-            values.append(value)
+        print(value)
 
-        # Verify that values are monotonically increasing
-        assert all(values[i] <= values[i + 1] for i in range(len(values) - 1))
+        assert value == pytest.approx(target_value * expected_percentage, rel=1e-3)
 
-        # Verify final value is approaching target
-        assert values[-1] == pytest.approx(1.0, rel=0.3)  # Should be close to 1.0 but not quite there
-
-    def test_multiple_target_changes(self, system: FirstOrderDelaySystemStepResponce):
-        """Test system response to multiple target value changes."""
-        # First target
+    def test_response_direction(self, system: FirstOrderDelaySystemStepResponce):
+        """Test system response in both positive and negative directions."""
+        # Test increasing response
         system.set_target_value(1.0)
-        values1 = [system.step() for _ in range(5)]
+        values_up = [system.step() for _ in range(5)]
+        assert all(values_up[i] < values_up[i + 1] for i in range(len(values_up) - 1))
 
-        # Change target midway
+        # Test decreasing response
         system.set_target_value(-1.0)
-        values2 = [system.step() for _ in range(5)]
-
-        # Verify direction changes
-        assert all(values1[i] <= values1[i + 1] for i in range(len(values1) - 1))  # Increasing
-        assert all(values2[i] >= values2[i + 1] for i in range(len(values2) - 1))  # Decreasing
+        values_down = [system.step() for _ in range(5)]
+        assert all(values_down[i] > values_down[i + 1] for i in range(len(values_down) - 1))
 
     def test_zero_response(self, system: FirstOrderDelaySystemStepResponce):
         """Test system response when target equals initial value."""
         system.set_target_value(0.0)  # Same as initial value
         for _ in range(10):
             value = system.step()
-            assert value == pytest.approx(0.0, abs=1e-10)
+            assert value == 0.0  # Should be exactly zero, no approximation needed
+
+    def test_step_timing(self, system: FirstOrderDelaySystemStepResponce):
+        """Test that elapsed time is correctly updated."""
+        system.set_target_value(1.0)
+
+        # Step multiple times and check elapsed time
+        steps = 5
+        for i in range(steps):
+            system.step()
+            assert system._current_elapsed_time == pytest.approx((i + 1) * system.delta_time)


### PR DESCRIPTION
## 概要

#162 issueではなぜかオイラー法で積分する方法を書いていますが、普通に解析解が求まるのでそれで実装しました。

## 変更内容

<!-- ビューの変更がある場合はスクショによる比較などがあるとわかりやすい -->

## 影響範囲

<!-- この関数を変更したのでこの機能にも影響がある、など -->

## Submit前の確認項目

<!-- PRをSubmitする前に確認する項目 -->

- [ ] タイトルは一目でわかるようにし、説明文は PR を簡潔に説明するようにしましたか?
- [ ] あなたの PR が、異なる変更を束ねたものではなく、ひとつのことだけを行うものであることを確認しましたか?
- [ ] この PR で導入されたすべての変更点をリストアップしましたか?
- [ ] PR を`make run`コマンドでローカルでテストしましたか?

## 補足

<!-- レビューをする際に見てほしい点、ローカル環境で試す際の注意点、など -->
