### PR TITLE
波形のサンプル数に関連した変数名の変更

### DIFF
--- a/ami/models/components/audio_patchifier.py
+++ b/ami/models/components/audio_patchifier.py
@@ -72,7 +72,7 @@ class AudioPatchifier(nn.Module):
 
         Args:
             x (torch.Tensor):
-                Input audios. Shape is [batch_size, n_channels, n_samples].
+                Input audios. Shape is [batch_size, n_channels, sample_size].
 
         Returns:
             torch.Tensor:

--- a/ami/trainers/components/bool_audio_jepa_mask_collator.py
+++ b/ami/trainers/components/bool_audio_jepa_mask_collator.py
@@ -32,7 +32,7 @@ class BoolAudioJEPAMultiBlockMaskCollator:
         """Initialize the BoolAudioJEPAMultiBlockMaskCollator.
 
         Args:
-            input_sample_size (size_2d):
+            input_sample_size (int):
                 Num of samples in the input audio.
             patch_sample_size (int):
                 Size of each patch. It can also be regarded as window_size.

--- a/ami/trainers/components/bool_audio_jepa_mask_collator.py
+++ b/ami/trainers/components/bool_audio_jepa_mask_collator.py
@@ -22,8 +22,8 @@ class BoolAudioJEPAMultiBlockMaskCollator:
 
     def __init__(
         self,
-        input_size: int,
-        patch_size: int,
+        input_sample_size: int,
+        patch_sample_size: int,
         stride: int,
         mask_scale: tuple[float, float] = (0.10, 0.25),  # masking 1/10 ~ 1/4 region
         n_masks: int = 4,
@@ -32,9 +32,9 @@ class BoolAudioJEPAMultiBlockMaskCollator:
         """Initialize the BoolAudioJEPAMultiBlockMaskCollator.
 
         Args:
-            input_size (size_2d):
+            input_sample_size (size_2d):
                 Num of samples in the input audio.
-            patch_size (int):
+            patch_sample_size (int):
                 Size of each patch. It can also be regarded as window_size.
             stride (int):
                 Stride during making patches from audio. It can also be regarded as hop_size.
@@ -50,13 +50,13 @@ class BoolAudioJEPAMultiBlockMaskCollator:
         assert mask_scale[0] > 0
         assert mask_scale[1] < 1
 
-        assert patch_size <= input_size
-        assert stride <= patch_size
-        assert (input_size - (patch_size - stride)) % stride == 0
-        self.input_size = input_size
-        self.patch_size = patch_size
+        assert patch_sample_size <= input_sample_size
+        assert stride <= patch_sample_size
+        assert (input_sample_size - (patch_sample_size - stride)) % stride == 0
+        self.input_sample_size = input_sample_size
+        self.patch_sample_size = patch_sample_size
 
-        self.n_patches = (input_size - (self.patch_size - stride)) // stride
+        self.n_patches = (input_sample_size - (self.patch_sample_size - stride)) // stride
         assert min_keep <= self.n_patches
 
         self.mask_scale = mask_scale
@@ -90,14 +90,14 @@ class BoolAudioJEPAMultiBlockMaskCollator:
 
         # Given scale, compute n_samples of mask.
         num_patches_max = self.n_patches
-        n_samples_of_mask = round(mask_scale * num_patches_max)
+        mask_sample_size = round(mask_scale * num_patches_max)
 
         # clamp with [1, self.n_patches]
-        n_samples_of_mask = min(max(n_samples_of_mask, 1), self.n_patches)
+        mask_sample_size = min(max(mask_sample_size, 1), self.n_patches)
 
         # Compute mask coordinates
-        start = int(torch.randint(high=self.n_patches - n_samples_of_mask + 1, size=(1,), generator=generator).item())
-        end = start + n_samples_of_mask
+        start = int(torch.randint(high=self.n_patches - mask_sample_size + 1, size=(1,), generator=generator).item())
+        end = start + mask_sample_size
         return start, end
 
     def sample_masks_and_target(self, generator: torch.Generator) -> tuple[Tensor, Tensor]:
@@ -155,7 +155,7 @@ class BoolAudioJEPAMultiBlockMaskCollator:
                     Boolean masks representing predictor targets (shape: [batch_size, n_patches])
         """
         collated_audios: Tensor = default_collate(audios)[0]
-        assert collated_audios.size(-1) == self.input_size
+        assert collated_audios.size(-1) == self.input_sample_size
 
         seed = self.step()
         g = torch.Generator()

--- a/tests/models/components/test_audio_patchifier.py
+++ b/tests/models/components/test_audio_patchifier.py
@@ -6,16 +6,16 @@ from ami.models.components.audio_patchifier import AudioPatchifier
 
 class TestAudioPatchifier:
     @pytest.mark.parametrize("batch_size", [1, 4])
-    @pytest.mark.parametrize("n_samples", [400, 16080])
+    @pytest.mark.parametrize("sample_size", [400, 16080])
     @pytest.mark.parametrize("in_channels", [1, 2])  # monoral and stereo audio respectively.
     @pytest.mark.parametrize("embed_dim", [512])
-    def test_forward(self, batch_size: int, n_samples: int, in_channels: int, embed_dim: int):
+    def test_forward(self, batch_size: int, sample_size: int, in_channels: int, embed_dim: int):
         audio_patchifier = AudioPatchifier(in_channels=in_channels, embed_dim=embed_dim)
-        input_audios = torch.randn(batch_size, in_channels, n_samples)
+        input_audios = torch.randn(batch_size, in_channels, sample_size)
         output_patches = audio_patchifier(input_audios)
         assert isinstance(output_patches, torch.Tensor)
         # According to data2vec paper (https://arxiv.org/abs/2202.03555),
         # assuming window_size=400[samples] and hop_size=320[samples] as total.
         window_size, hop_size = 400, 320
-        expected_n_patches = int((n_samples - 400) / 320) + 1
+        expected_n_patches = int((sample_size - 400) / 320) + 1
         assert output_patches.shape == (batch_size, expected_n_patches, embed_dim)

--- a/tests/trainers/components/test_bool_audio_jepa_mask_collator.py
+++ b/tests/trainers/components/test_bool_audio_jepa_mask_collator.py
@@ -8,27 +8,27 @@ from ami.trainers.components.bool_audio_jepa_mask_collator import (
 
 class TestBoolAudioJEPAMultiBlockMaskCollator:
     @pytest.mark.parametrize(
-        ["input_size", "patch_size", "stride", "mask_scale", "n_masks", "min_keep"],
+        ["input_sample_size", "patch_sample_size", "stride", "mask_scale", "n_masks", "min_keep"],
         [
             [16080, 400, 320, (0.1, 0.25), 4, 10],
         ],
     )
     def test_sample_mask(
         self,
-        input_size: int,
-        patch_size: int,
+        input_sample_size: int,
+        patch_sample_size: int,
         stride: int,
         mask_scale: tuple[float, float],
         n_masks: int,
         min_keep: int,
     ):
-        assert patch_size <= input_size
-        assert stride <= input_size
-        assert (input_size - (patch_size - stride)) % stride == 0
+        assert patch_sample_size <= input_sample_size
+        assert stride <= input_sample_size
+        assert (input_sample_size - (patch_sample_size - stride)) % stride == 0
         # define BoolAudioJEPAMultiBlockMaskCollator
         collator = BoolAudioJEPAMultiBlockMaskCollator(
-            input_size=input_size,
-            patch_size=patch_size,
+            input_sample_size=input_sample_size,
+            patch_sample_size=patch_sample_size,
             stride=stride,
             mask_scale=mask_scale,
             n_masks=n_masks,
@@ -36,24 +36,24 @@ class TestBoolAudioJEPAMultiBlockMaskCollator:
         )
         g = torch.Generator()
         # calc num of patches
-        n_patches = (input_size - (patch_size - stride)) / stride
+        n_patches = (input_sample_size - (patch_sample_size - stride)) / stride
         for _ in range(100):
             start, end = collator._sample_mask(g)
             assert start < end
             assert start >= 0
-            assert end <= input_size
+            assert end <= input_sample_size
 
-            n_samples_of_mask = end - start
+            mask_sample_size = end - start
             # test mask scale
             mask_scale_min, mask_scale_max = mask_scale
-            assert n_samples_of_mask <= mask_scale_max * n_patches
-            assert n_samples_of_mask >= mask_scale_min * n_patches
+            assert mask_sample_size <= mask_scale_max * n_patches
+            assert mask_sample_size >= mask_scale_min * n_patches
             # test min keep
-            assert (n_patches - n_samples_of_mask) >= min_keep
+            assert (n_patches - mask_sample_size) >= min_keep
 
     # collator params
     @pytest.mark.parametrize(
-        ["input_size", "patch_size", "stride", "mask_scale", "n_masks", "min_keep"],
+        ["input_sample_size", "patch_sample_size", "stride", "mask_scale", "n_masks", "min_keep"],
         [
             [16080, 400, 320, (0.1, 0.25), 4, 10],
         ],
@@ -63,8 +63,8 @@ class TestBoolAudioJEPAMultiBlockMaskCollator:
     @pytest.mark.parametrize("n_channels", [1, 2])  # monoral and stereo audio respectively
     def test_bool_i_jepa_mask_collator(
         self,
-        input_size: int,
-        patch_size: int,
+        input_sample_size: int,
+        patch_sample_size: int,
         stride: int,
         mask_scale: tuple[float, float],
         n_masks: int,
@@ -72,20 +72,20 @@ class TestBoolAudioJEPAMultiBlockMaskCollator:
         batch_size: int,
         n_channels: int,
     ):
-        assert patch_size <= input_size
-        assert stride <= input_size
-        assert (input_size - (patch_size - stride)) % stride == 0
+        assert patch_sample_size <= input_sample_size
+        assert stride <= input_sample_size
+        assert (input_sample_size - (patch_sample_size - stride)) % stride == 0
         # define BoolAudioJEPAMultiBlockMaskCollator
         collator = BoolAudioJEPAMultiBlockMaskCollator(
-            input_size=input_size,
-            patch_size=patch_size,
+            input_sample_size=input_sample_size,
+            patch_sample_size=patch_sample_size,
             stride=stride,
             mask_scale=mask_scale,
             n_masks=n_masks,
             min_keep=min_keep,
         )
         # define sample inputs
-        audios = [(torch.randn([n_channels, input_size]),) for _ in range(batch_size)]
+        audios = [(torch.randn([n_channels, input_sample_size]),) for _ in range(batch_size)]
         # collate batch and create masks
         (
             collated_audios,
@@ -96,10 +96,10 @@ class TestBoolAudioJEPAMultiBlockMaskCollator:
         # check image sizes
         assert collated_audios.size(0) == batch_size, "batch_size mismatch"
         assert collated_audios.size(1) == n_channels, "channels mismatch"
-        assert collated_audios.size(2) == input_size, "collated_audios num of samples mismatch"
+        assert collated_audios.size(2) == input_sample_size, "collated_audios num of samples mismatch"
 
         # calc num of patches
-        n_patches = (input_size - (patch_size - stride)) // stride
+        n_patches = (input_sample_size - (patch_sample_size - stride)) // stride
 
         # check masks for context encoder
         assert collated_encoder_masks.dim() == 2
@@ -127,27 +127,27 @@ class TestBoolAudioJEPAMultiBlockMaskCollator:
         ), "encoder masks and predictor targets must be different"
 
     @pytest.mark.parametrize(
-        ["input_size", "patch_size", "stride", "mask_scale", "n_masks", "min_keep"],
+        ["input_sample_size", "patch_sample_size", "stride", "mask_scale", "n_masks", "min_keep"],
         [
             [16080, 400, 320, (0.1, 0.25), 4, 10],
         ],
     )
     def test_sample_masks_and_target(
         self,
-        input_size: int,
-        patch_size: int,
+        input_sample_size: int,
+        patch_sample_size: int,
         stride: int,
         mask_scale: tuple[float, float],
         n_masks: int,
         min_keep: int,
     ):
-        assert patch_size <= input_size
-        assert stride <= input_size
-        assert (input_size - (patch_size - stride)) % stride == 0
+        assert patch_sample_size <= input_sample_size
+        assert stride <= input_sample_size
+        assert (input_sample_size - (patch_sample_size - stride)) % stride == 0
         # define BoolAudioJEPAMultiBlockMaskCollator
         collator = BoolAudioJEPAMultiBlockMaskCollator(
-            input_size=input_size,
-            patch_size=patch_size,
+            input_sample_size=input_sample_size,
+            patch_sample_size=patch_sample_size,
             stride=stride,
             mask_scale=mask_scale,
             n_masks=n_masks,
@@ -157,7 +157,7 @@ class TestBoolAudioJEPAMultiBlockMaskCollator:
         encoder_mask, predictor_target = collator.sample_masks_and_target(g)
 
         # calc num of patches
-        n_patches = (input_size - (patch_size - stride)) // stride
+        n_patches = (input_sample_size - (patch_sample_size - stride)) // stride
 
         assert encoder_mask.shape == (n_patches,)
         assert predictor_target.shape == (n_patches,)


### PR DESCRIPTION
## 概要

波形のサンプル数に関連した変数名について、`size`や`n_samples`など表記揺れが発生している箇所を、https://github.com/MLShukai/ami-vconf24/blob/main/ami/interactions/environments/sensors/soundcard_audio_sensor.py に倣い`sample_size`という表記に変更

## 変更内容

<!-- ビューの変更がある場合はスクショによる比較などがあるとわかりやすい -->

## 影響範囲

<!-- この関数を変更したのでこの機能にも影響がある、など -->

## Submit前の確認項目

<!-- PRをSubmitする前に確認する項目 -->

- [x] タイトルは一目でわかるようにし、説明文は PR を簡潔に説明するようにしましたか?
- [x] あなたの PR が、異なる変更を束ねたものではなく、ひとつのことだけを行うものであることを確認しましたか?
- [x] この PR で導入されたすべての変更点をリストアップしましたか?
- [x] PR を`make run`コマンドでローカルでテストしましたか?

## 補足

<!-- レビューをする際に見てほしい点、ローカル環境で試す際の注意点、など -->
