### PR TITLE
ParallelScan版SioConv実装

### DIFF
--- a/ami/models/components/sioconvps.py
+++ b/ami/models/components/sioconvps.py
@@ -1,4 +1,4 @@
-import numpy as np
+# SioConv with Parallel Scan  (PS)
 import torch
 import torch.nn as nn
 import torch.nn.functional as F

--- a/ami/models/components/sioconvps.py
+++ b/ami/models/components/sioconvps.py
@@ -1,0 +1,101 @@
+import numpy as np
+import torch
+import torch.nn as nn
+import torch.nn.functional as F
+from torch import Tensor
+
+from .stacked_hidden_state import StackedHiddenState
+
+
+class RMSNorm(nn.Module):
+    def __init__(self, dim: int, eps: float = 1e-6, elementwise_affine: bool = True):
+        super().__init__()
+        self.normalized_shape = dim
+        self.eps = eps
+        self.elementwise_affine = elementwise_affine
+        self.weight: nn.Parameter | None = nn.Parameter(torch.ones(dim)) if self.elementwise_affine else None
+
+    def forward(self, x: Tensor) -> Tensor:
+        output = x * torch.rsqrt(x.pow(2).mean(-1, keepdim=True) + self.eps)
+        if self.weight is not None:
+            output = output * self.weight
+        return output
+
+
+class FFNSwiGLU(nn.Module):
+    def __init__(self, dim: int, dim_ff_hidden: int):
+        super().__init__()
+        self.fc = nn.Linear(dim, dim_ff_hidden)
+        self.fc_act = nn.Linear(dim, dim_ff_hidden)
+        self.fc_out = nn.Linear(dim_ff_hidden, dim)
+        self.act = nn.SiLU()
+
+    def forward(self, x: Tensor) -> Tensor:
+        x = self.fc(x) * self.act(self.fc_act(x))
+        x = self.fc_out(x)
+        return x
+
+
+class SioConvPSLayer(nn.Module):
+    def __init__(self, dim: int):
+        super().__init__()
+        self.dim = dim
+        self.fc_ln_z = nn.Linear(dim, dim)
+        self.fc_y = nn.Linear(dim, dim)
+        self.fc_y_act = nn.Linear(dim, dim)
+        self.act = nn.SiLU()
+        self.fc_dt = nn.Linear(dim, dim)
+        self.last_hidden = None
+        self.last_hidden_init = nn.Parameter(torch.randn(dim))
+        self.is_refresh = True
+
+    # (batch, len, dim), (batch, dim) -> (batch, len, dim), (batch, len, dim)
+    def forward(self, x: Tensor, hidden: Tensor) -> tuple[Tensor, Tensor]:
+        ln_z = -F.softplus(-self.fc_ln_z(x))  # (batch, len, dim)
+
+        ln_da = -F.softplus(-self.fc_dt(x))  # (batch, len, dim)
+        ln_z_da = ln_z + ln_da
+        ln_o_da = -F.softplus(self.fc_dt(x))  # (batch, len, dim)
+        ln_o_da_cumsum = torch.cumsum(ln_o_da, dim=1)
+
+        ln_z_da_ln_o_da_cumsum = ln_z_da - ln_o_da_cumsum  # (batch, len, dim)
+        logcumsumexp_ln_z_da_ln_o_da_cumsum = torch.logcumsumexp(ln_z_da_ln_o_da_cumsum, dim=1)  # (batch, len, dim)
+
+        h_inner_chunk = torch.exp(logcumsumexp_ln_z_da_ln_o_da_cumsum + ln_o_da_cumsum)  # (batch, len, dim)
+
+        h_cross_chunk = torch.einsum("bld,bd->bld", torch.exp(ln_o_da_cumsum), hidden)  # (batch, len, dim)
+
+        h = h_inner_chunk + h_cross_chunk
+
+        y = self.fc_y(h) * self.act(self.fc_y_act(x))
+        return y, h
+
+
+class SioConvPSBlock(nn.Module):
+    def __init__(self, dim: int, dim_ff_hidden: int, dropout: float):
+        super().__init__()
+        self.sioconv = SioConvPSLayer(dim)
+        self.ffn = FFNSwiGLU(dim, dim_ff_hidden)
+        self.norm_sioconv = RMSNorm(dim)
+        self.norm_ffn = RMSNorm(dim)
+        self.dropout = nn.Dropout(dropout)
+
+    def forward(self, x: Tensor, hidden: Tensor) -> tuple[Tensor, Tensor]:
+        x_ = x
+        x = self.norm_sioconv(x)
+        x, hidden = self.sioconv(x, hidden)
+        x = self.dropout(x)
+        x = x + x_
+
+        x_ = x
+        x = self.norm_ffn(x)
+        x = self.ffn(x)
+        x = self.dropout(x)
+        x = x + x_
+
+        return x, hidden
+
+
+class SioConvPS(StackedHiddenState):
+    def __init__(self, depth: int, dim: int, dim_ff_hidden: int, dropout: float):
+        super().__init__(nn.ModuleList([SioConvPSBlock(dim, dim_ff_hidden, dropout) for _ in range(depth)]))

--- a/ami/models/components/sioconvps.py
+++ b/ami/models/components/sioconvps.py
@@ -45,9 +45,6 @@ class SioConvPSLayer(nn.Module):
         self.fc_y_act = nn.Linear(dim, dim)
         self.act = nn.SiLU()
         self.fc_dt = nn.Linear(dim, dim)
-        self.last_hidden = None
-        self.last_hidden_init = nn.Parameter(torch.randn(dim))
-        self.is_refresh = True
 
     # (batch, len, dim), (batch, dim) -> (batch, len, dim), (batch, len, dim)
     def forward(self, x: Tensor, hidden: Tensor) -> tuple[Tensor, Tensor]:

--- a/tests/models/components/test_sioconvps.py
+++ b/tests/models/components/test_sioconvps.py
@@ -1,0 +1,32 @@
+import pytest
+import torch
+
+from ami.models.components.sioconvps import SioConvPS
+
+BATCH = 4
+DEPTH = 8
+DIM = 16
+DIM_FF_HIDDEN = 32
+LEN = 64
+DROPOUT = 0.1
+
+
+class TestSioConvPS:
+    @pytest.fixture
+    def sioconvps(self):
+        sioconvps = SioConvPS(DEPTH, DIM, DIM_FF_HIDDEN, DROPOUT)
+        return sioconvps
+
+    def test_sioconvps(self, sioconvps):
+        x_shape = (BATCH, LEN, DIM)
+        x = torch.randn(*x_shape)
+        hidden_shape = (BATCH, DEPTH, LEN, DIM)
+        hidden = torch.randn(*hidden_shape)
+
+        x, hidden = sioconvps(x, hidden[:, :, -1, :])
+        assert x.shape == x_shape
+        assert hidden.shape == hidden_shape
+
+        x, hidden = sioconvps(x, hidden[:, :, -1, :])
+        assert x.shape == x_shape
+        assert hidden.shape == hidden_shape


### PR DESCRIPTION
## 概要

<!-- 変更の目的 もしくは 関連する Issue 番号 -->
minGRUで使われているParallelScanを取り込んだSioConv
ヘッド毎の忘却が次元数に増えた

## 変更内容

<!-- ビューの変更がある場合はスクショによる比較などがあるとわかりやすい -->

## 影響範囲

<!-- この関数を変更したのでこの機能にも影響がある、など -->

## Submit前の確認項目

<!-- PRをSubmitする前に確認する項目 -->

- [x] タイトルは一目でわかるようにし、説明文は PR を簡潔に説明するようにしましたか?
- [x] あなたの PR が、異なる変更を束ねたものではなく、ひとつのことだけを行うものであることを確認しましたか?
- [x] この PR で導入されたすべての変更点をリストアップしましたか?
- [x] PR を`make run`コマンドでローカルでテストしましたか?

## 補足

<!-- レビューをする際に見てほしい点、ローカル環境で試す際の注意点、など -->
