### PR TITLE
デフォルトマイクを環境変数から設定可能に

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,4 @@
+# Example `.env` file. Please rename this file to `.env` for adding environment variables
+
+# Specify default microphone device name.
+# AMI_DEFAULT_MICROPHONE="some sound card"

--- a/ami/interactions/environments/sensors/soundcard_audio_sensor.py
+++ b/ami/interactions/environments/sensors/soundcard_audio_sensor.py
@@ -1,3 +1,4 @@
+import logging
 import math
 import os
 import threading
@@ -10,6 +11,8 @@ from typing_extensions import override
 from vrchat_io.audio import SoundcardAudioCapture
 
 from .base_sensor import BaseSensor
+
+logger = logging.getLogger(__name__)
 
 
 class SoundcardAudioSensor(BaseSensor[Tensor]):
@@ -57,6 +60,9 @@ class SoundcardAudioSensor(BaseSensor[Tensor]):
 
         if device_name is None:
             device_name = os.environ.get("AMI_DEFAULT_MICROPHONE")
+
+        if device_name is not None:
+            logger.debug(f"Using audio device: {device_name}")
 
         self._cap = SoundcardAudioCapture(sample_rate, device_name, frame_size=block_size, channels=channel_size)
         self._sampled_blocks: deque[Tensor] = deque(

--- a/ami/interactions/environments/sensors/soundcard_audio_sensor.py
+++ b/ami/interactions/environments/sensors/soundcard_audio_sensor.py
@@ -1,4 +1,5 @@
 import math
+import os
 import threading
 import time
 from collections import deque
@@ -53,6 +54,9 @@ class SoundcardAudioSensor(BaseSensor[Tensor]):
         self._block_size = block_size
         self._read_sample_size = read_sample_size
         self._dtype = dtype
+
+        if device_name is None:
+            device_name = os.environ.get("AMI_DEFAULT_MICROPHONE")
 
         self._cap = SoundcardAudioCapture(sample_rate, device_name, frame_size=block_size, channels=channel_size)
         self._sampled_blocks: deque[Tensor] = deque(

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -24,6 +24,7 @@ hydra-joblib-launcher = "^1.2.0"
 matplotlib = "^3.9.2"
 seaborn = "^0.13.2"
 soundfile = "^0.12.1"
+python-dotenv = "^1.0.1"
 
 
 [tool.poetry.group.dev.dependencies]

--- a/scripts/show_microphones.py
+++ b/scripts/show_microphones.py
@@ -1,0 +1,5 @@
+#!python
+import soundcard as sc
+
+for mic in sc.all_microphones(True):
+    print(f"{mic.id}: {mic.name}")


### PR DESCRIPTION
## 概要

<!-- 変更の目的 もしくは 関連する Issue 番号 -->

## 変更内容

#189 デフォルトマイクのidを`.env`ファイルに書き込むことによって環境ごとに指定可能にしました。

## 影響範囲

<!-- この関数を変更したのでこの機能にも影響がある、など -->

## Submit前の確認項目

<!-- PRをSubmitする前に確認する項目 -->

- [ ] タイトルは一目でわかるようにし、説明文は PR を簡潔に説明するようにしましたか?
- [ ] あなたの PR が、異なる変更を束ねたものではなく、ひとつのことだけを行うものであることを確認しましたか?
- [ ] この PR で導入されたすべての変更点をリストアップしましたか?
- [ ] PR を`make run`コマンドでローカルでテストしましたか?

## 補足

<!-- レビューをする際に見てほしい点、ローカル環境で試す際の注意点、など -->
